### PR TITLE
add any and all strategies

### DIFF
--- a/src/main/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl.java
@@ -1,0 +1,144 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ * Copyright (c) 2019, Bodybuilding.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.branch.buildstrategies.basic;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.Util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import jenkins.branch.BranchBuildStrategy;
+import jenkins.branch.BranchBuildStrategyDescriptor;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.SCMSource;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * A {@link BranchBuildStrategy} that builds branches based on the results of all sub strategies matching.
+ *
+ * @since 1.0.1
+ */
+public class AllBranchBuildStrategyImpl extends BranchBuildStrategy {
+
+    /**
+     * The list of filters.
+     */
+    @NonNull
+    private final List<BranchBuildStrategy> strategies;
+
+    /**
+     * Our constructor.
+     * @param strategies the strategies to apply.
+     */
+    @DataBoundConstructor
+    public AllBranchBuildStrategyImpl(List<BranchBuildStrategy> strategies) {
+        this.strategies = new ArrayList<>(Util.fixNull(strategies));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
+                                    SCMRevision prevRevision) {
+
+        if(strategies.isEmpty()){
+            return false;
+        }
+
+        for (BranchBuildStrategy strategy: strategies) {
+            if(!strategy.isAutomaticBuild(
+                source,
+                head,
+                currRevision,
+                prevRevision
+            )){
+                return false;
+            };
+
+        }
+        return true;
+    }
+
+    @NonNull
+    public List<BranchBuildStrategy> getStrategies() {
+        return Collections.unmodifiableList(strategies);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AllBranchBuildStrategyImpl that = (AllBranchBuildStrategyImpl) o;
+
+        return strategies.equals(that.strategies);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return strategies.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "AllBranchBuildStrategyImpl{" +
+                "strategies=" + strategies +
+                '}';
+    }
+
+
+    /**
+     * Our descriptor.
+     */
+    @Symbol("buildAllBranches")
+    @Extension
+    public static class DescriptorImpl extends BranchBuildStrategyDescriptor {
+        /**
+         * {@inheritDoc}
+         */
+        @NonNull
+        @Override
+        public String getDisplayName() {
+            return Messages.AllBranchBuildStrategyImpl_displayName();
+        }
+    }
+
+}

--- a/src/main/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl.java
@@ -1,8 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2018, CloudBees, Inc.
- * Copyright (c) 2019, Bodybuilding.com
+ * Copyright (c) 2018-2019, Bodybuilding.com, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl.java
@@ -1,0 +1,145 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ * Copyright (c) 2019, Bodybuilding.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.branch.buildstrategies.basic;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.Util;
+import jenkins.branch.BranchBuildStrategy;
+import jenkins.branch.BranchBuildStrategyDescriptor;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.SCMSource;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A {@link BranchBuildStrategy} that builds branches based on the results of any sub strategy matching.
+ *
+ * @since 1.0.1
+ */
+public class AnyBranchBuildStrategyImpl extends BranchBuildStrategy {
+
+    /**
+     * The list of sub strategies.
+     */
+    @NonNull
+    private final List<BranchBuildStrategy> strategies;
+
+    /**
+     * Our constructor.
+     * @param strategies the strategies to apply.
+     */
+    @DataBoundConstructor
+    public AnyBranchBuildStrategyImpl(List<BranchBuildStrategy> strategies) {
+        this.strategies = new ArrayList<>(Util.fixNull(strategies));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
+                                    SCMRevision prevRevision) {
+
+        if(strategies.isEmpty()){
+            return false;
+        }
+
+        for (BranchBuildStrategy strategy: strategies) {
+            if(strategy.isAutomaticBuild(
+                source,
+                head,
+                currRevision,
+                prevRevision
+            )){
+                return true;
+            };
+
+        }
+        return false;
+    }
+
+    @NonNull
+    public List<BranchBuildStrategy> getStrategies() {
+        return Collections.unmodifiableList(strategies);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AnyBranchBuildStrategyImpl that = (AnyBranchBuildStrategyImpl) o;
+
+        return strategies.equals(that.strategies);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return strategies.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "AnyBranchBuildStrategyImpl{" +
+                "strategies=" + strategies +
+                '}';
+    }
+
+
+    /**
+     * Our descriptor.
+     */
+    @Symbol("buildAnyBranches")
+    @Extension
+    public static class DescriptorImpl extends BranchBuildStrategyDescriptor {
+        /**
+         * {@inheritDoc}
+         */
+        @NonNull
+        @Override
+        public String getDisplayName() {
+            return Messages.AnyBranchBuildStrategyImpl_displayName();
+        }
+    }
+
+
+
+}

--- a/src/main/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl.java
@@ -1,8 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2018, CloudBees, Inc.
- * Copyright (c) 2019, Bodybuilding.com
+ * Copyright (c) 2018-2019, Bodybuilding.com, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl.java
@@ -1,0 +1,144 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018-2019, Bodybuilding.com, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.branch.buildstrategies.basic;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.Util;
+import jenkins.branch.BranchBuildStrategy;
+import jenkins.branch.BranchBuildStrategyDescriptor;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.SCMSource;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A {@link BranchBuildStrategy} that builds branches based on the results of all sub strategy NOT matching.
+ *
+ * @since 1.0.1
+ */
+public class NoneBranchBuildStrategyImpl extends BranchBuildStrategy {
+
+    /**
+     * The list of sub strategies.
+     */
+    @NonNull
+    private final List<BranchBuildStrategy> strategies;
+
+    /**
+     * Our constructor.
+     * @param strategies the strategies to apply.
+     */
+    @DataBoundConstructor
+    public NoneBranchBuildStrategyImpl(List<BranchBuildStrategy> strategies) {
+        this.strategies = new ArrayList<>(Util.fixNull(strategies));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
+                                    SCMRevision prevRevision) {
+
+        if(strategies.isEmpty()){
+            return false;
+        }
+
+        for (BranchBuildStrategy strategy: strategies) {
+            if(strategy.isAutomaticBuild(
+                source,
+                head,
+                currRevision,
+                prevRevision
+            )){
+                return false;
+            };
+
+        }
+        return true;
+    }
+
+    @NonNull
+    public List<BranchBuildStrategy> getStrategies() {
+        return Collections.unmodifiableList(strategies);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        NoneBranchBuildStrategyImpl that = (NoneBranchBuildStrategyImpl) o;
+
+        return strategies.equals(that.strategies);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return strategies.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "NoneBranchBuildStrategyImpl{" +
+                "strategies=" + strategies +
+                '}';
+    }
+
+
+    /**
+     * Our descriptor.
+     */
+    @Symbol("buildNoneBranches")
+    @Extension
+    public static class DescriptorImpl extends BranchBuildStrategyDescriptor {
+        /**
+         * {@inheritDoc}
+         */
+        @NonNull
+        @Override
+        public String getDisplayName() {
+            return Messages.NoneBranchBuildStrategyImpl_displayName();
+        }
+    }
+
+
+
+}

--- a/src/main/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl.java
@@ -138,7 +138,6 @@ public class NoneBranchBuildStrategyImpl extends BranchBuildStrategy {
             return Messages.NoneBranchBuildStrategyImpl_displayName();
         }
     }
-
-
+    
 
 }

--- a/src/main/resources/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl/config.jelly
+++ b/src/main/resources/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl/config.jelly
@@ -1,0 +1,30 @@
+<!--
+ ~ The MIT License
+ ~
+ ~ Copyright (c) 2018, CloudBees, Inc.
+ ~ Copyright (c) 2019, Bodybuilding.com
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+ ~ of this software and associated documentation files (the "Software"), to deal
+ ~ in the Software without restriction, including without limitation the rights
+ ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ ~ copies of the Software, and to permit persons to whom the Software is
+ ~ furnished to do so, subject to the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be included in
+ ~ all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ ~ THE SOFTWARE.
+ -->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:entry field="strategies" title="${%All Of}">
+    <f:repeatableHeteroProperty field="strategies" hasHeader="true"/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl/config.jelly
+++ b/src/main/resources/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl/config.jelly
@@ -1,8 +1,7 @@
 <!--
  ~ The MIT License
  ~
- ~ Copyright (c) 2018, CloudBees, Inc.
- ~ Copyright (c) 2019, Bodybuilding.com
+ ~ Copyright (c) 2018-2019, Bodybuilding.com, CloudBees, Inc.
  ~
  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
  ~ of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl/config.jelly
+++ b/src/main/resources/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl/config.jelly
@@ -24,7 +24,7 @@
  -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-  <f:entry field="strategies" title="${%All Of}">
+  <f:entry field="strategies" title="${%All of}">
     <f:repeatableHeteroProperty field="strategies" hasHeader="true"/>
   </f:entry>
 </j:jelly>

--- a/src/main/resources/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl/help-strategies.html
+++ b/src/main/resources/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl/help-strategies.html
@@ -1,8 +1,7 @@
 <!--
  ~ The MIT License
  ~
- ~ Copyright (c) 2018, CloudBees, Inc.
- ~ Copyright (c) 2019, Bodybuilding.com
+ ~ Copyright (c) 2018-2019, Bodybuilding.com, CloudBees, Inc.
  ~
  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
  ~ of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl/help-strategies.html
+++ b/src/main/resources/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl/help-strategies.html
@@ -1,0 +1,27 @@
+<!--
+ ~ The MIT License
+ ~
+ ~ Copyright (c) 2018, CloudBees, Inc.
+ ~ Copyright (c) 2019, Bodybuilding.com
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+ ~ of this software and associated documentation files (the "Software"), to deal
+ ~ in the Software without restriction, including without limitation the rights
+ ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ ~ copies of the Software, and to permit persons to whom the Software is
+ ~ furnished to do so, subject to the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be included in
+ ~ all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ ~ THE SOFTWARE.
+ -->
+<div>
+    The strategies to check when matching. All must pass for this strategy to match.
+</div>

--- a/src/main/resources/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl/help.html
+++ b/src/main/resources/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl/help.html
@@ -23,5 +23,5 @@
  ~ THE SOFTWARE.
  -->
 <div>
-  Builds named branches whenever all sub strategies match.
+  Builds branches only if all the sub strategies match.
 </div>

--- a/src/main/resources/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl/help.html
+++ b/src/main/resources/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl/help.html
@@ -1,8 +1,7 @@
 <!--
  ~ The MIT License
  ~
- ~ Copyright (c) 2018, CloudBees, Inc.
- ~ Copyright (c) 2019, Bodybuilding.com
+ ~ Copyright (c) 2018-2019, Bodybuilding.com, CloudBees, Inc.
  ~
  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
  ~ of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl/help.html
+++ b/src/main/resources/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl/help.html
@@ -1,0 +1,27 @@
+<!--
+ ~ The MIT License
+ ~
+ ~ Copyright (c) 2018, CloudBees, Inc.
+ ~ Copyright (c) 2019, Bodybuilding.com
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+ ~ of this software and associated documentation files (the "Software"), to deal
+ ~ in the Software without restriction, including without limitation the rights
+ ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ ~ copies of the Software, and to permit persons to whom the Software is
+ ~ furnished to do so, subject to the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be included in
+ ~ all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ ~ THE SOFTWARE.
+ -->
+<div>
+  Builds named branches whenever all sub strategies match.
+</div>

--- a/src/main/resources/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl/config.jelly
+++ b/src/main/resources/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl/config.jelly
@@ -24,7 +24,7 @@
  -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-  <f:entry field="strategies" title="${%Any Of}">
+  <f:entry field="strategies" title="${%Any of}">
     <f:repeatableHeteroProperty field="strategies" hasHeader="true"/>
   </f:entry>
 </j:jelly>

--- a/src/main/resources/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl/config.jelly
+++ b/src/main/resources/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl/config.jelly
@@ -1,8 +1,7 @@
 <!--
  ~ The MIT License
  ~
- ~ Copyright (c) 2018, CloudBees, Inc.
- ~ Copyright (c) 2019, Bodybuilding.com
+ ~ Copyright (c) 2018-2019, Bodybuilding.com, CloudBees, Inc.
  ~
  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
  ~ of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl/config.jelly
+++ b/src/main/resources/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl/config.jelly
@@ -1,0 +1,30 @@
+<!--
+ ~ The MIT License
+ ~
+ ~ Copyright (c) 2018, CloudBees, Inc.
+ ~ Copyright (c) 2019, Bodybuilding.com
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+ ~ of this software and associated documentation files (the "Software"), to deal
+ ~ in the Software without restriction, including without limitation the rights
+ ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ ~ copies of the Software, and to permit persons to whom the Software is
+ ~ furnished to do so, subject to the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be included in
+ ~ all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ ~ THE SOFTWARE.
+ -->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:entry field="strategies" title="${%Any Of}">
+    <f:repeatableHeteroProperty field="strategies" hasHeader="true"/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl/help-strategies.html
+++ b/src/main/resources/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl/help-strategies.html
@@ -1,8 +1,7 @@
 <!--
  ~ The MIT License
  ~
- ~ Copyright (c) 2018, CloudBees, Inc.
- ~ Copyright (c) 2019, Bodybuilding.com
+ ~ Copyright (c) 2018-2019, Bodybuilding.com, CloudBees, Inc.
  ~
  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
  ~ of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl/help-strategies.html
+++ b/src/main/resources/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl/help-strategies.html
@@ -1,0 +1,27 @@
+<!--
+ ~ The MIT License
+ ~
+ ~ Copyright (c) 2018, CloudBees, Inc.
+ ~ Copyright (c) 2019, Bodybuilding.com
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+ ~ of this software and associated documentation files (the "Software"), to deal
+ ~ in the Software without restriction, including without limitation the rights
+ ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ ~ copies of the Software, and to permit persons to whom the Software is
+ ~ furnished to do so, subject to the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be included in
+ ~ all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ ~ THE SOFTWARE.
+ -->
+<div>
+    The strategies to check when matching. Any must pass for this strategy to match.
+</div>

--- a/src/main/resources/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl/help-strategies.html
+++ b/src/main/resources/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl/help-strategies.html
@@ -22,5 +22,5 @@
  ~ THE SOFTWARE.
  -->
 <div>
-    The strategies to check when matching. Any must pass for this strategy to match.
+    The strategies to check when matching. Any must match for the any strategy to match.
 </div>

--- a/src/main/resources/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl/help.html
+++ b/src/main/resources/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl/help.html
@@ -1,0 +1,27 @@
+<!--
+ ~ The MIT License
+ ~
+ ~ Copyright (c) 2018, CloudBees, Inc.
+ ~ Copyright (c) 2019, Bodybuilding.com
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+ ~ of this software and associated documentation files (the "Software"), to deal
+ ~ in the Software without restriction, including without limitation the rights
+ ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ ~ copies of the Software, and to permit persons to whom the Software is
+ ~ furnished to do so, subject to the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be included in
+ ~ all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ ~ THE SOFTWARE.
+ -->
+<div>
+  Builds named branches whenever any sub strategies match.
+</div>

--- a/src/main/resources/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl/help.html
+++ b/src/main/resources/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl/help.html
@@ -1,8 +1,7 @@
 <!--
  ~ The MIT License
  ~
- ~ Copyright (c) 2018, CloudBees, Inc.
- ~ Copyright (c) 2019, Bodybuilding.com
+ ~ Copyright (c) 2018-2019, Bodybuilding.com, CloudBees, Inc.
  ~
  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
  ~ of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl/help.html
+++ b/src/main/resources/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl/help.html
@@ -23,5 +23,5 @@
  ~ THE SOFTWARE.
  -->
 <div>
-  Builds named branches whenever any sub strategies match.
+  Builds whenever any of the sub strategies match.
 </div>

--- a/src/main/resources/jenkins/branch/buildstrategies/basic/Messages.properties
+++ b/src/main/resources/jenkins/branch/buildstrategies/basic/Messages.properties
@@ -3,5 +3,7 @@ NamedBranchBuildStrategyImpl.displayName=Named branches
 NamedBranchBuildStrategyImpl.exactDisplayName=Exact name
 NamedBranchBuildStrategyImpl.regexDisplayName=Regular expression
 NamedBranchBuildStrategyImpl.wildcardDisplayName=Wildcard include/excludes
+AllBranchBuildStrategyImpl.displayName=All Strategies Match
+AnyBranchBuildStrategyImpl.displayName=Any Strategies Match
 TagBuildStrategyImpl.displayName=Tags
 ChangeRequestBuildStrategyImpl.displayName=Change requests

--- a/src/main/resources/jenkins/branch/buildstrategies/basic/Messages.properties
+++ b/src/main/resources/jenkins/branch/buildstrategies/basic/Messages.properties
@@ -5,5 +5,6 @@ NamedBranchBuildStrategyImpl.regexDisplayName=Regular expression
 NamedBranchBuildStrategyImpl.wildcardDisplayName=Wildcard include/excludes
 AllBranchBuildStrategyImpl.displayName=All Strategies Match
 AnyBranchBuildStrategyImpl.displayName=Any Strategies Match
+NoneBranchBuildStrategyImpl.displayName=None Strategies Match
 TagBuildStrategyImpl.displayName=Tags
 ChangeRequestBuildStrategyImpl.displayName=Change requests

--- a/src/main/resources/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl/config.jelly
+++ b/src/main/resources/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl/config.jelly
@@ -21,6 +21,9 @@
  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  ~ THE SOFTWARE.
  -->
-<div>
-    The strategies to check when matching. All must match for this strategy to match.
-</div>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:entry field="strategies" title="${%None of}">
+    <f:repeatableHeteroProperty field="strategies" hasHeader="true"/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl/help-strategies.html
+++ b/src/main/resources/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl/help-strategies.html
@@ -22,5 +22,5 @@
  ~ THE SOFTWARE.
  -->
 <div>
-    The strategies to check when matching. All must match for this strategy to match.
+    The strategies to check when matching. All must NOT match for the none strategy to match.
 </div>

--- a/src/main/resources/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl/help.html
+++ b/src/main/resources/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl/help.html
@@ -22,5 +22,5 @@
  ~ THE SOFTWARE.
  -->
 <div>
-    The strategies to check when matching. All must match for this strategy to match.
+  Builds branches only if none of the sub strategies match.
 </div>

--- a/src/test/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImplTest.java
@@ -1,8 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2018, CloudBees, Inc.
- * Copyright (c) 2019, Bodybuilding.com
+ * Copyright (c) 2018-2019, Bodybuilding.com, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImplTest.java
@@ -1,0 +1,153 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ * Copyright (c) 2019, Bodybuilding.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.branch.buildstrategies.basic;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import jenkins.branch.BranchBuildStrategy;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.impl.mock.MockSCMController;
+import jenkins.scm.impl.mock.MockSCMHead;
+import jenkins.scm.impl.mock.MockSCMRevision;
+import jenkins.scm.impl.mock.MockSCMSource;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class AllBranchBuildStrategyImplTest {
+    @Test
+    public void given__no_strategies__when__isAutomaticBuild__then__returns_false() throws Exception {
+        try (MockSCMController c = MockSCMController.create()) {
+            MockSCMHead head = new MockSCMHead("master");
+            assertThat(
+                new AllBranchBuildStrategyImpl(Collections.emptyList()
+                ).isAutomaticBuild(
+                    new MockSCMSource(c, "dummy"),
+                    head,
+                    new MockSCMRevision(head, "dummy"),
+                    null
+                ),
+                is(false)
+            );
+        }
+    }
+
+
+    @Test
+    public void given__true_strategies__when__isAutomaticBuild__then__returns_true() throws Exception {
+        try (MockSCMController c = MockSCMController.create()) {
+            MockSCMHead head = new MockSCMHead("master");
+            assertThat(
+                new AllBranchBuildStrategyImpl(Arrays.asList(
+                    new BranchBuildStrategy() {
+                        @Override
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                            return true;
+                        }
+                    },
+                    new BranchBuildStrategy() {
+                        @Override
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                            return true;
+                        }
+                    }
+                )).isAutomaticBuild(
+                    new MockSCMSource(c, "dummy"),
+                    head,
+                    new MockSCMRevision(head, "dummy"),
+                    null
+                ),
+                is(true)
+            );
+        }
+    }
+
+    @Test
+    public void given__false_strategies__when__isAutomaticBuild__then__returns_false() throws Exception {
+        try (MockSCMController c = MockSCMController.create()) {
+            MockSCMHead head = new MockSCMHead("master");
+            assertThat(
+                new AllBranchBuildStrategyImpl(Arrays.asList(
+                    new BranchBuildStrategy() {
+                        @Override
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                            return false;
+                        }
+                    },
+                    new BranchBuildStrategy() {
+                        @Override
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                            return false;
+                        }
+                    }
+                )).isAutomaticBuild(
+                    new MockSCMSource(c, "dummy"),
+                    head,
+                    new MockSCMRevision(head, "dummy"),
+                    null
+                ),
+                is(false)
+            );
+        }
+    }
+
+
+    @Test
+    public void given__false_and_true_strategies__when__isAutomaticBuild__then__returns_false_with_short_circuit() throws Exception {
+        try (MockSCMController c = MockSCMController.create()) {
+            MockSCMHead head = new MockSCMHead("master");
+            assertThat(
+                new AllBranchBuildStrategyImpl(Arrays.asList(
+                    new BranchBuildStrategy() {
+                        @Override
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                            return false;
+                        }
+                    },
+                    new BranchBuildStrategy() {
+                        @Override
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                            fail("strategy evaluation must short circuit");
+                            return true;
+                        }
+                    }
+                )).isAutomaticBuild(
+                    new MockSCMSource(c, "dummy"),
+                    head,
+                    new MockSCMRevision(head, "dummy"),
+                    null
+                ),
+                is(false)
+            );
+        }
+    }
+
+}

--- a/src/test/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImplTest.java
@@ -1,8 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2018, CloudBees, Inc.
- * Copyright (c) 2019, Bodybuilding.com
+ * Copyright (c) 2018-2019, Bodybuilding.com, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImplTest.java
@@ -1,0 +1,153 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ * Copyright (c) 2019, Bodybuilding.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.branch.buildstrategies.basic;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import jenkins.branch.BranchBuildStrategy;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.impl.mock.MockSCMController;
+import jenkins.scm.impl.mock.MockSCMHead;
+import jenkins.scm.impl.mock.MockSCMRevision;
+import jenkins.scm.impl.mock.MockSCMSource;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class AnyBranchBuildStrategyImplTest {
+    @Test
+    public void given__no_strategies__when__isAutomaticBuild__then__returns_false() throws Exception {
+        try (MockSCMController c = MockSCMController.create()) {
+            MockSCMHead head = new MockSCMHead("master");
+            assertThat(
+                new AnyBranchBuildStrategyImpl(Collections.emptyList()
+                ).isAutomaticBuild(
+                    new MockSCMSource(c, "dummy"),
+                    head,
+                    new MockSCMRevision(head, "dummy"),
+                    null
+                ),
+                is(false)
+            );
+        }
+    }
+
+
+    @Test
+    public void given__true_strategies__when__isAutomaticBuild__then__returns_true() throws Exception {
+        try (MockSCMController c = MockSCMController.create()) {
+            MockSCMHead head = new MockSCMHead("master");
+            assertThat(
+                new AnyBranchBuildStrategyImpl(Arrays.asList(
+                    new BranchBuildStrategy() {
+                        @Override
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                            return true;
+                        }
+                    },
+                    new BranchBuildStrategy() {
+                        @Override
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                            return true;
+                        }
+                    }
+                )).isAutomaticBuild(
+                    new MockSCMSource(c, "dummy"),
+                    head,
+                    new MockSCMRevision(head, "dummy"),
+                    null
+                ),
+                is(true)
+            );
+        }
+    }
+
+    @Test
+    public void given__false_strategies__when__isAutomaticBuild__then__returns_false() throws Exception {
+        try (MockSCMController c = MockSCMController.create()) {
+            MockSCMHead head = new MockSCMHead("master");
+            assertThat(
+                new AnyBranchBuildStrategyImpl(Arrays.asList(
+                    new BranchBuildStrategy() {
+                        @Override
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                            return false;
+                        }
+                    },
+                    new BranchBuildStrategy() {
+                        @Override
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                            return false;
+                        }
+                    }
+                )).isAutomaticBuild(
+                    new MockSCMSource(c, "dummy"),
+                    head,
+                    new MockSCMRevision(head, "dummy"),
+                    null
+                ),
+                is(false)
+            );
+        }
+    }
+
+
+    @Test
+    public void given__true_and_false_strategies__when__isAutomaticBuild__then__returns_true_with_short_circuit() throws Exception {
+        try (MockSCMController c = MockSCMController.create()) {
+            MockSCMHead head = new MockSCMHead("master");
+            assertThat(
+                new AnyBranchBuildStrategyImpl(Arrays.asList(
+                    new BranchBuildStrategy() {
+                        @Override
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                            return true;
+                        }
+                    },
+                    new BranchBuildStrategy() {
+                        @Override
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                            fail("strategy evaluation must short circuit");
+                            return false;
+                        }
+                    }
+                )).isAutomaticBuild(
+                    new MockSCMSource(c, "dummy"),
+                    head,
+                    new MockSCMRevision(head, "dummy"),
+                    null
+                ),
+                is(true)
+            );
+        }
+    }
+
+}

--- a/src/test/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImplTest.java
@@ -1,0 +1,152 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018-2019, Bodybuilding.com, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.branch.buildstrategies.basic;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import jenkins.branch.BranchBuildStrategy;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.impl.mock.MockSCMController;
+import jenkins.scm.impl.mock.MockSCMHead;
+import jenkins.scm.impl.mock.MockSCMRevision;
+import jenkins.scm.impl.mock.MockSCMSource;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class NoneBranchBuildStrategyImplTest {
+    @Test
+    public void given__no_strategies__when__isAutomaticBuild__then__returns_false() throws Exception {
+        try (MockSCMController c = MockSCMController.create()) {
+            MockSCMHead head = new MockSCMHead("master");
+            assertThat(
+                new NoneBranchBuildStrategyImpl(Collections.emptyList()
+                ).isAutomaticBuild(
+                    new MockSCMSource(c, "dummy"),
+                    head,
+                    new MockSCMRevision(head, "dummy"),
+                    null
+                ),
+                is(false)
+            );
+        }
+    }
+
+
+    @Test
+    public void given__true_strategies__when__isAutomaticBuild__then__returns_false() throws Exception {
+        try (MockSCMController c = MockSCMController.create()) {
+            MockSCMHead head = new MockSCMHead("master");
+            assertThat(
+                new NoneBranchBuildStrategyImpl(Arrays.asList(
+                    new BranchBuildStrategy() {
+                        @Override
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                            return true;
+                        }
+                    },
+                    new BranchBuildStrategy() {
+                        @Override
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                            return true;
+                        }
+                    }
+                )).isAutomaticBuild(
+                    new MockSCMSource(c, "dummy"),
+                    head,
+                    new MockSCMRevision(head, "dummy"),
+                    null
+                ),
+                is(false)
+            );
+        }
+    }
+
+    @Test
+    public void given__false_strategies__when__isAutomaticBuild__then__returns_true() throws Exception {
+        try (MockSCMController c = MockSCMController.create()) {
+            MockSCMHead head = new MockSCMHead("master");
+            assertThat(
+                new NoneBranchBuildStrategyImpl(Arrays.asList(
+                    new BranchBuildStrategy() {
+                        @Override
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                            return false;
+                        }
+                    },
+                    new BranchBuildStrategy() {
+                        @Override
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                            return false;
+                        }
+                    }
+                )).isAutomaticBuild(
+                    new MockSCMSource(c, "dummy"),
+                    head,
+                    new MockSCMRevision(head, "dummy"),
+                    null
+                ),
+                is(true)
+            );
+        }
+    }
+
+
+    @Test
+    public void given__true_and_false_strategies__when__isAutomaticBuild__then__returns_false_with_short_circuit() throws Exception {
+        try (MockSCMController c = MockSCMController.create()) {
+            MockSCMHead head = new MockSCMHead("master");
+            assertThat(
+                new NoneBranchBuildStrategyImpl(Arrays.asList(
+                    new BranchBuildStrategy() {
+                        @Override
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                            return true;
+                        }
+                    },
+                    new BranchBuildStrategy() {
+                        @Override
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                            fail("strategy evaluation must short circuit");
+                            return false;
+                        }
+                    }
+                )).isAutomaticBuild(
+                    new MockSCMSource(c, "dummy"),
+                    head,
+                    new MockSCMRevision(head, "dummy"),
+                    null
+                ),
+                is(false)
+            );
+        }
+    }
+
+}


### PR DESCRIPTION
I'm finding it necessary to have some basic logic for build strategies, like i want tags and PRS or i want regular branches, but NOT with certain commit messages.

these two recursive strategies allow you to build just about any logic.

I could publish as standalone extension..but these seem liek very basic building blocks so thought a PR more appropriate.  But maybe maintaining this is not desireable.

for example this would help with the requests at https://issues.jenkins-ci.org/browse/JENKINS-48296

<img width="769" alt="screen shot 2019-02-19 at 12 26 29 am" src="https://user-images.githubusercontent.com/1514496/52998477-9c54ba00-33e0-11e9-9fd4-7e0d22802bbb.png">
