### PR TITLE
[JENKINS-38552] BranchBuildStrategy to skip the initial build on the first branch indexing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
   <properties>
     <java.level>8</java.level>
     <jenkins.version>2.107.3</jenkins.version>
-    <scm-api.version>2.3.2</scm-api.version>
+    <scm-api.version>2.4.0</scm-api.version>
   </properties>
 
   <repositories>
@@ -94,7 +94,12 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>branch-api</artifactId>
-      <version>2.1.0</version>
+      <version>2.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>structs</artifactId>
+      <version>1.10</version>
     </dependency>
     <!-- jenkins dependencies -->
     <!-- test dependencies -->

--- a/src/main/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import hudson.model.TaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
@@ -66,7 +67,7 @@ public class AllBranchBuildStrategyImpl extends BranchBuildStrategy {
      */
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision prevRevision) {
+                                    SCMRevision prevRevision, TaskListener taskListener) {
 
         if(strategies.isEmpty()){
             return false;
@@ -77,7 +78,8 @@ public class AllBranchBuildStrategyImpl extends BranchBuildStrategy {
                 source,
                 head,
                 currRevision,
-                prevRevision
+                prevRevision,
+                taskListener
             )){
                 return false;
             };

--- a/src/main/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl.java
@@ -26,6 +26,7 @@ package jenkins.branch.buildstrategies.basic;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
+import hudson.model.TaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
@@ -65,7 +66,7 @@ public class AnyBranchBuildStrategyImpl extends BranchBuildStrategy {
      */
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision prevRevision) {
+                                    SCMRevision prevRevision, TaskListener taskListener) {
 
         if(strategies.isEmpty()){
             return false;
@@ -76,7 +77,8 @@ public class AnyBranchBuildStrategyImpl extends BranchBuildStrategy {
                 source,
                 head,
                 currRevision,
-                prevRevision
+                prevRevision,
+                taskListener
             )){
                 return true;
             };

--- a/src/main/java/jenkins/branch/buildstrategies/basic/BranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/BranchBuildStrategyImpl.java
@@ -25,6 +25,7 @@ package jenkins.branch.buildstrategies.basic;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import hudson.model.TaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
@@ -53,7 +54,7 @@ public class BranchBuildStrategyImpl extends BranchBuildStrategy {
      */
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision prevRevision) {
+                                    SCMRevision prevRevision, TaskListener taskListener) {
         if (head instanceof ChangeRequestSCMHead) {
             return false;
         }

--- a/src/main/java/jenkins/branch/buildstrategies/basic/ChangeRequestBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/ChangeRequestBuildStrategyImpl.java
@@ -94,10 +94,10 @@ public class ChangeRequestBuildStrategyImpl extends BranchBuildStrategy {
         return ignoreUntrustedChanges;
     }
 
-    // TODO change overload to one that has the listener after branch-api is updated to enable listener pass-through
     /**
      * {@inheritDoc}
      */
+    @Deprecated
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     @CheckForNull SCMRevision prevRevision) {
@@ -107,8 +107,8 @@ public class ChangeRequestBuildStrategyImpl extends BranchBuildStrategy {
     /**
      * {@inheritDoc}
      */
-    // TODO @Override
     @Restricted(ProtectedExternally.class)
+    @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     @CheckForNull SCMRevision prevRevision, TaskListener listener) {
         if (!(head instanceof ChangeRequestSCMHead)) {

--- a/src/main/java/jenkins/branch/buildstrategies/basic/NamedBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/NamedBranchBuildStrategyImpl.java
@@ -29,6 +29,7 @@ import hudson.Extension;
 import hudson.Util;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+import hudson.model.TaskListener;
 import hudson.util.FormValidation;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -77,7 +78,7 @@ public class NamedBranchBuildStrategyImpl extends BranchBuildStrategy {
      */
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision prevRevision) {
+                                    SCMRevision prevRevision, TaskListener taskListener) {
         if (head instanceof ChangeRequestSCMHead) {
             return false;
         }

--- a/src/main/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl.java
@@ -26,6 +26,7 @@ package jenkins.branch.buildstrategies.basic;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
+import hudson.model.TaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
@@ -65,7 +66,7 @@ public class NoneBranchBuildStrategyImpl extends BranchBuildStrategy {
      */
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision prevRevision) {
+                                    SCMRevision prevRevision, TaskListener taskListener) {
 
         if(strategies.isEmpty()){
             return false;
@@ -76,7 +77,8 @@ public class NoneBranchBuildStrategyImpl extends BranchBuildStrategy {
                 source,
                 head,
                 currRevision,
-                prevRevision
+                prevRevision,
+                    taskListener
             )){
                 return false;
             };

--- a/src/main/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexing.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexing.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package jenkins.branch.buildstrategies.basic;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/src/main/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexing.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexing.java
@@ -1,0 +1,48 @@
+package jenkins.branch.buildstrategies.basic;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import jenkins.branch.BranchBuildStrategy;
+import jenkins.branch.BranchBuildStrategyDescriptor;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.SCMSource;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+
+@Restricted(NoExternalUse.class)
+@Extension
+public class SkipInitialBuildOnFirstBranchIndexing extends BranchBuildStrategy {
+
+    @DataBoundConstructor
+    public SkipInitialBuildOnFirstBranchIndexing() {
+
+    }
+
+    @Override
+    public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision currRevision, SCMRevision prevRevision) {
+        if (prevRevision != null) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Our descriptor.
+     */
+    @Extension
+    public static class DescriptorImpl extends BranchBuildStrategyDescriptor {
+        /**
+         * {@inheritDoc}
+         */
+        @NonNull
+        @Override
+        public String getDisplayName() {
+            return Messages.SkipInitialBuildOnFirstBranchIndexing_displayName();
+        }
+
+    }
+
+}

--- a/src/main/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexing.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexing.java
@@ -25,6 +25,7 @@ package jenkins.branch.buildstrategies.basic;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import hudson.model.TaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
@@ -45,7 +46,7 @@ public class SkipInitialBuildOnFirstBranchIndexing extends BranchBuildStrategy {
     }
 
     @Override
-    public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision currRevision, SCMRevision prevRevision) {
+    public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision currRevision, SCMRevision prevRevision, TaskListener taskListener) {
         if (prevRevision != null) {
             return true;
         }

--- a/src/main/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImpl.java
@@ -28,6 +28,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import java.util.concurrent.TimeUnit;
+
+import hudson.model.TaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
@@ -114,7 +116,7 @@ public class TagBuildStrategyImpl extends BranchBuildStrategy {
      */
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    @CheckForNull SCMRevision prevRevision) {
+                                    @CheckForNull SCMRevision prevRevision, TaskListener taskListener) {
         if (!(head instanceof TagSCMHead)) {
             return false;
         }

--- a/src/main/resources/jenkins/branch/buildstrategies/basic/Messages.properties
+++ b/src/main/resources/jenkins/branch/buildstrategies/basic/Messages.properties
@@ -8,3 +8,4 @@ AnyBranchBuildStrategyImpl.displayName=Any Strategies Match
 NoneBranchBuildStrategyImpl.displayName=None Strategies Match
 TagBuildStrategyImpl.displayName=Tags
 ChangeRequestBuildStrategyImpl.displayName=Change requests
+SkipInitialBuildOnFirstBranchIndexing.displayName=Skip initial build on first branch indexing

--- a/src/main/resources/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexing/help.html
+++ b/src/main/resources/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexing/help.html
@@ -1,0 +1,26 @@
+<!--
+ ~ The MIT License
+ ~
+ ~ Copyright (c) 2018, CloudBees, Inc.
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+ ~ of this software and associated documentation files (the "Software"), to deal
+ ~ in the Software without restriction, including without limitation the rights
+ ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ ~ copies of the Software, and to permit persons to whom the Software is
+ ~ furnished to do so, subject to the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be included in
+ ~ all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ ~ THE SOFTWARE.
+ -->
+<div>
+  Skip initial build on first branch indexing
+</div>

--- a/src/main/resources/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexing/help.html
+++ b/src/main/resources/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexing/help.html
@@ -22,5 +22,5 @@
  ~ THE SOFTWARE.
  -->
 <div>
-  Skip initial build on first branch indexing (Only works since branch-api-plugin 2.2.1)
+  Skip initial build on first branch indexing
 </div>

--- a/src/main/resources/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexing/help.html
+++ b/src/main/resources/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexing/help.html
@@ -1,7 +1,7 @@
 <!--
  ~ The MIT License
  ~
- ~ Copyright (c) 2018, CloudBees, Inc.
+ ~ Copyright (c) 2019, CloudBees, Inc.
  ~
  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
  ~ of this software and associated documentation files (the "Software"), to deal
@@ -22,5 +22,5 @@
  ~ THE SOFTWARE.
  -->
 <div>
-  Skip initial build on first branch indexing
+  Skip initial build on first branch indexing (Only works since branch-api-plugin 2.2.1)
 </div>

--- a/src/test/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImplTest.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.TaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
@@ -52,6 +53,7 @@ public class AllBranchBuildStrategyImplTest {
                     new MockSCMSource(c, "dummy"),
                     head,
                     new MockSCMRevision(head, "dummy"),
+                    null,
                     null
                 ),
                 is(false)
@@ -68,13 +70,13 @@ public class AllBranchBuildStrategyImplTest {
                 new AllBranchBuildStrategyImpl(Arrays.asList(
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
                             return true;
                         }
                     },
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
                             return true;
                         }
                     }
@@ -82,7 +84,8 @@ public class AllBranchBuildStrategyImplTest {
                     new MockSCMSource(c, "dummy"),
                     head,
                     new MockSCMRevision(head, "dummy"),
-                    null
+                        null,
+                        null
                 ),
                 is(true)
             );
@@ -97,13 +100,13 @@ public class AllBranchBuildStrategyImplTest {
                 new AllBranchBuildStrategyImpl(Arrays.asList(
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
                             return false;
                         }
                     },
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
                             return false;
                         }
                     }
@@ -111,7 +114,8 @@ public class AllBranchBuildStrategyImplTest {
                     new MockSCMSource(c, "dummy"),
                     head,
                     new MockSCMRevision(head, "dummy"),
-                    null
+                    null,
+                        null
                 ),
                 is(false)
             );
@@ -127,13 +131,13 @@ public class AllBranchBuildStrategyImplTest {
                 new AllBranchBuildStrategyImpl(Arrays.asList(
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
                             return false;
                         }
                     },
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
                             fail("strategy evaluation must short circuit");
                             return true;
                         }
@@ -142,6 +146,7 @@ public class AllBranchBuildStrategyImplTest {
                     new MockSCMSource(c, "dummy"),
                     head,
                     new MockSCMRevision(head, "dummy"),
+                    null,
                     null
                 ),
                 is(false)

--- a/src/test/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImplTest.java
@@ -24,6 +24,7 @@
 package jenkins.branch.buildstrategies.basic;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.TaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
@@ -52,7 +53,8 @@ public class AnyBranchBuildStrategyImplTest {
                     new MockSCMSource(c, "dummy"),
                     head,
                     new MockSCMRevision(head, "dummy"),
-                    null
+                    null,
+                        null
                 ),
                 is(false)
             );
@@ -68,13 +70,13 @@ public class AnyBranchBuildStrategyImplTest {
                 new AnyBranchBuildStrategyImpl(Arrays.asList(
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
                             return true;
                         }
                     },
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
                             return true;
                         }
                     }
@@ -82,7 +84,8 @@ public class AnyBranchBuildStrategyImplTest {
                     new MockSCMSource(c, "dummy"),
                     head,
                     new MockSCMRevision(head, "dummy"),
-                    null
+                    null,
+                        null
                 ),
                 is(true)
             );
@@ -97,13 +100,13 @@ public class AnyBranchBuildStrategyImplTest {
                 new AnyBranchBuildStrategyImpl(Arrays.asList(
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
                             return false;
                         }
                     },
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
                             return false;
                         }
                     }
@@ -111,7 +114,8 @@ public class AnyBranchBuildStrategyImplTest {
                     new MockSCMSource(c, "dummy"),
                     head,
                     new MockSCMRevision(head, "dummy"),
-                    null
+                    null,
+                        null
                 ),
                 is(false)
             );
@@ -127,13 +131,13 @@ public class AnyBranchBuildStrategyImplTest {
                 new AnyBranchBuildStrategyImpl(Arrays.asList(
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
                             return true;
                         }
                     },
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
                             fail("strategy evaluation must short circuit");
                             return false;
                         }
@@ -142,6 +146,7 @@ public class AnyBranchBuildStrategyImplTest {
                     new MockSCMSource(c, "dummy"),
                     head,
                     new MockSCMRevision(head, "dummy"),
+                    null,
                     null
                 ),
                 is(true)

--- a/src/test/java/jenkins/branch/buildstrategies/basic/BranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/BranchBuildStrategyImplTest.java
@@ -47,6 +47,7 @@ public class BranchBuildStrategyImplTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
+                            null,
                             null
                     ),
                     is(true)
@@ -63,6 +64,7 @@ public class BranchBuildStrategyImplTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
+                            null,
                             null
                     ),
                     is(false)
@@ -81,6 +83,7 @@ public class BranchBuildStrategyImplTest {
                             head,
                             new MockChangeRequestSCMRevision(head,
                                     new MockSCMRevision(new MockSCMHead("master"), "dummy"), "dummy"),
+                            null,
                             null
                     ),
                     is(false)

--- a/src/test/java/jenkins/branch/buildstrategies/basic/NamedBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/NamedBranchBuildStrategyImplTest.java
@@ -51,6 +51,7 @@ public class NamedBranchBuildStrategyImplTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
+                            null,
                             null
                     ),
                     is(true)
@@ -69,6 +70,7 @@ public class NamedBranchBuildStrategyImplTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
+                            null,
                             null
                     ),
                     is(false)
@@ -89,6 +91,7 @@ public class NamedBranchBuildStrategyImplTest {
                             head,
                             new MockChangeRequestSCMRevision(head,
                                     new MockSCMRevision(new MockSCMHead("master"), "dummy"), "dummy"),
+                            null,
                             null
                     ),
                     is(false)
@@ -107,6 +110,7 @@ public class NamedBranchBuildStrategyImplTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
+                            null,
                             null
                     ),
                     is(false)
@@ -129,6 +133,7 @@ public class NamedBranchBuildStrategyImplTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
+                            null,
                             null
                     ),
                     is(false)
@@ -151,6 +156,7 @@ public class NamedBranchBuildStrategyImplTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
+                            null,
                             null
                     ),
                     is(true)
@@ -173,6 +179,7 @@ public class NamedBranchBuildStrategyImplTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
+                            null,
                             null
                     ),
                     is(true)

--- a/src/test/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImplTest.java
@@ -24,6 +24,7 @@
 package jenkins.branch.buildstrategies.basic;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.TaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
@@ -52,6 +53,7 @@ public class NoneBranchBuildStrategyImplTest {
                     new MockSCMSource(c, "dummy"),
                     head,
                     new MockSCMRevision(head, "dummy"),
+                    null,
                     null
                 ),
                 is(false)
@@ -68,13 +70,13 @@ public class NoneBranchBuildStrategyImplTest {
                 new NoneBranchBuildStrategyImpl(Arrays.asList(
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
                             return true;
                         }
                     },
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
                             return true;
                         }
                     }
@@ -82,6 +84,7 @@ public class NoneBranchBuildStrategyImplTest {
                     new MockSCMSource(c, "dummy"),
                     head,
                     new MockSCMRevision(head, "dummy"),
+                    null,
                     null
                 ),
                 is(false)
@@ -97,13 +100,13 @@ public class NoneBranchBuildStrategyImplTest {
                 new NoneBranchBuildStrategyImpl(Arrays.asList(
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
                             return false;
                         }
                     },
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
                             return false;
                         }
                     }
@@ -111,6 +114,7 @@ public class NoneBranchBuildStrategyImplTest {
                     new MockSCMSource(c, "dummy"),
                     head,
                     new MockSCMRevision(head, "dummy"),
+                    null,
                     null
                 ),
                 is(true)
@@ -127,13 +131,13 @@ public class NoneBranchBuildStrategyImplTest {
                 new NoneBranchBuildStrategyImpl(Arrays.asList(
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
                             return true;
                         }
                     },
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
                             fail("strategy evaluation must short circuit");
                             return false;
                         }
@@ -142,6 +146,7 @@ public class NoneBranchBuildStrategyImplTest {
                     new MockSCMSource(c, "dummy"),
                     head,
                     new MockSCMRevision(head, "dummy"),
+                    null,
                     null
                 ),
                 is(false)

--- a/src/test/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexingTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexingTest.java
@@ -1,16 +1,62 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package jenkins.branch.buildstrategies.basic;
 
+import hudson.model.FreeStyleProject;
+import jenkins.branch.BranchBuildStrategy;
+import jenkins.branch.BranchSource;
+import jenkins.branch.buildstrategies.basic.harness.BasicMultiBranchProject;
+import jenkins.scm.api.SCMEvent;
+import jenkins.scm.api.SCMEvents;
+import jenkins.scm.api.SCMHeadEvent;
 import jenkins.scm.impl.mock.MockSCMController;
+import jenkins.scm.impl.mock.MockSCMDiscoverBranches;
 import jenkins.scm.impl.mock.MockSCMHead;
+import jenkins.scm.impl.mock.MockSCMHeadEvent;
 import jenkins.scm.impl.mock.MockSCMRevision;
 import jenkins.scm.impl.mock.MockSCMSource;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Collections;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
 
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
 
 public class SkipInitialBuildOnFirstBranchIndexingTest {
+
+    /**
+     * All tests in this class only create items and do not affect other global configuration, thus we trade test
+     * execution time for the restriction on only touching items.
+     */
+    @ClassRule
+    public static JenkinsRule j = new JenkinsRule();
+
     @Test
     public void given__no__scm__prev_revision__isAutomaticBuild__then__returns_false() throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
@@ -41,6 +87,58 @@ public class SkipInitialBuildOnFirstBranchIndexingTest {
                     is(true)
             );
         }
+    }
+
+    @Test
+    public void in__first__branch__indexing__isAutomaticBuild__then__returns__true() throws Exception {
+        try (MockSCMController c = MockSCMController.create()) {
+            c.createRepository("foo");
+            BasicMultiBranchProject prj = j.jenkins.createProject(BasicMultiBranchProject.class, "foo");
+            prj.setCriteria(null);
+            BranchSource source = new BranchSource(new MockSCMSource(c, "foo", new MockSCMDiscoverBranches()));
+            source.setBuildStrategies(Collections.<BranchBuildStrategy>singletonList(new SkipInitialBuildOnFirstBranchIndexing()));
+            prj.getSourcesList().add(source);
+            fire(new MockSCMHeadEvent(SCMEvent.Type.CREATED, c, "foo", "master", c.getRevision("foo", "master")));
+            FreeStyleProject master = prj.getItem("master");
+            j.waitUntilNoActivity();
+            assertThat("The master branch was built", master.getLastBuild(), nullValue());
+            c.addFile("foo", "master", "adding file", "file", new byte[0]);
+            fire(new MockSCMHeadEvent(SCMEvent.Type.UPDATED, c, "foo", "master", c.getRevision("foo", "master")));
+            j.waitUntilNoActivity();
+            assertThat("The master branch was built", master.getLastBuild(), notNullValue());
+            assertThat("The master branch was built", master.getLastBuild().getNumber(), is(1));
+            c.addFile("foo", "master", "adding file", "file", new byte[0]);
+            fire(new MockSCMHeadEvent(SCMEvent.Type.UPDATED, c, "foo", "master", c.getRevision("foo", "master")));
+            j.waitUntilNoActivity();
+            assertThat("The master branch was built", master.getLastBuild(), notNullValue());
+            assertThat("The master branch was built", master.getLastBuild().getNumber(), is(2));
+        }
+    }
+
+    @Test
+    public void if__skipInitialBuildOnFirstBranchIndexing__is__disabled__first__branch__indexing__triggers__the__build() throws Exception {
+        try (MockSCMController c = MockSCMController.create()) {
+            c.createRepository("foo");
+            BasicMultiBranchProject prj = j.jenkins.createProject(BasicMultiBranchProject.class, "foo");
+            prj.setCriteria(null);
+            prj.getSourcesList().add(new BranchSource(new MockSCMSource(c, "foo", new MockSCMDiscoverBranches())));
+            fire(new MockSCMHeadEvent(SCMEvent.Type.CREATED, c, "foo", "master", c.getRevision("foo", "master")));
+            FreeStyleProject master = prj.getItem("master");
+            j.waitUntilNoActivity();
+            assertThat("The master branch was built", master.getLastBuild().getNumber(), is(1));
+            c.addFile("foo", "master", "adding file", "file", new byte[0]);
+            fire(new MockSCMHeadEvent(SCMEvent.Type.UPDATED, c, "foo", "master", c.getRevision("foo", "master")));
+            j.waitUntilNoActivity();
+            assertThat("The master branch was built", master.getLastBuild(), notNullValue());
+            assertThat("The master branch was built", master.getLastBuild().getNumber(), is(2));
+        }
+    }
+
+    private void fire(MockSCMHeadEvent event) throws Exception {
+        long watermark = SCMEvents.getWatermark();
+        SCMHeadEvent.fireNow(event);
+        SCMEvents.awaitAll(watermark);
+        j.waitUntilNoActivity();
     }
 
 }

--- a/src/test/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexingTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexingTest.java
@@ -1,0 +1,46 @@
+package jenkins.branch.buildstrategies.basic;
+
+import jenkins.scm.impl.mock.MockSCMController;
+import jenkins.scm.impl.mock.MockSCMHead;
+import jenkins.scm.impl.mock.MockSCMRevision;
+import jenkins.scm.impl.mock.MockSCMSource;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+
+public class SkipInitialBuildOnFirstBranchIndexingTest {
+    @Test
+    public void given__no__scm__prev_revision__isAutomaticBuild__then__returns_false() throws Exception {
+        try (MockSCMController c = MockSCMController.create()) {
+            MockSCMHead head = new MockSCMHead("master");
+            assertThat(
+                    new SkipInitialBuildOnFirstBranchIndexing().isAutomaticBuild(
+                            new MockSCMSource(c, "dummy"),
+                            head,
+                            new MockSCMRevision(head, "dummy"),
+                            null
+                    ),
+                    is(false)
+            );
+        }
+    }
+
+    @Test
+    public void given__scm__prev_revision__isAutomaticBuild__then__returns_true() throws Exception {
+        try (MockSCMController c = MockSCMController.create()) {
+            MockSCMHead head = new MockSCMHead("master");
+            assertThat(
+                    new SkipInitialBuildOnFirstBranchIndexing().isAutomaticBuild(
+                            new MockSCMSource(c, "dummy"),
+                            head,
+                            new MockSCMRevision(head, "dummy"),
+                            new MockSCMRevision(head, "dummy")
+                    ),
+                    is(true)
+            );
+        }
+    }
+
+}

--- a/src/test/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexingTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexingTest.java
@@ -66,6 +66,7 @@ public class SkipInitialBuildOnFirstBranchIndexingTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
+                            null,
                             null
                     ),
                     is(false)
@@ -82,7 +83,8 @@ public class SkipInitialBuildOnFirstBranchIndexingTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
-                            new MockSCMRevision(head, "dummy")
+                            new MockSCMRevision(head, "dummy"),
+                            null
                     ),
                     is(true)
             );
@@ -90,10 +92,10 @@ public class SkipInitialBuildOnFirstBranchIndexingTest {
     }
 
     @Test
-    public void in__first__branch__indexing__isAutomaticBuild__then__returns__true() throws Exception {
+    public void if__first__branch__indexing__isAutomaticBuild__then__returns__true() throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
             c.createRepository("foo");
-            BasicMultiBranchProject prj = j.jenkins.createProject(BasicMultiBranchProject.class, "foo");
+            BasicMultiBranchProject prj = j.jenkins.createProject(BasicMultiBranchProject.class, "my-project");
             prj.setCriteria(null);
             BranchSource source = new BranchSource(new MockSCMSource(c, "foo", new MockSCMDiscoverBranches()));
             source.setBuildStrategies(Collections.<BranchBuildStrategy>singletonList(new SkipInitialBuildOnFirstBranchIndexing()));
@@ -119,7 +121,7 @@ public class SkipInitialBuildOnFirstBranchIndexingTest {
     public void if__skipInitialBuildOnFirstBranchIndexing__is__disabled__first__branch__indexing__triggers__the__build() throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
             c.createRepository("foo");
-            BasicMultiBranchProject prj = j.jenkins.createProject(BasicMultiBranchProject.class, "foo");
+            BasicMultiBranchProject prj = j.jenkins.createProject(BasicMultiBranchProject.class, "my-project");
             prj.setCriteria(null);
             prj.getSourcesList().add(new BranchSource(new MockSCMSource(c, "foo", new MockSCMDiscoverBranches())));
             fire(new MockSCMHeadEvent(SCMEvent.Type.CREATED, c, "foo", "master", c.getRevision("foo", "master")));

--- a/src/test/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexingTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexingTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2018, CloudBees, Inc.
+ * Copyright (c) 2019, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImplTest.java
@@ -48,6 +48,7 @@ public class TagBuildStrategyImplTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
+                            null,
                             null
                     ),
                     is(false)
@@ -64,6 +65,7 @@ public class TagBuildStrategyImplTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
+                            null,
                             null
                     ),
                     is(true)
@@ -80,6 +82,7 @@ public class TagBuildStrategyImplTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
+                            null,
                             null
                     ),
                     is(true)
@@ -96,6 +99,7 @@ public class TagBuildStrategyImplTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
+                            null,
                             null
                     ),
                     is(false)
@@ -112,6 +116,7 @@ public class TagBuildStrategyImplTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
+                            null,
                             null
                     ),
                     is(false)
@@ -128,6 +133,7 @@ public class TagBuildStrategyImplTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
+                            null,
                             null
                     ),
                     is(true)
@@ -145,6 +151,7 @@ public class TagBuildStrategyImplTest {
                                 new MockSCMSource(c, "dummy"),
                                 head,
                                 new MockSCMRevision(head, "dummy"),
+                                null,
                                 null
                         ),
                         is(false)
@@ -162,6 +169,7 @@ public class TagBuildStrategyImplTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
+                            null,
                             null
                     ),
                     is(false)
@@ -178,6 +186,7 @@ public class TagBuildStrategyImplTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
+                            null,
                             null
                     ),
                     is(true)
@@ -194,6 +203,7 @@ public class TagBuildStrategyImplTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
+                            null,
                             null
                     ),
                     is(false)
@@ -212,6 +222,7 @@ public class TagBuildStrategyImplTest {
                             head,
                             new MockChangeRequestSCMRevision(head,
                                     new MockSCMRevision(new MockSCMHead("master"), "dummy"), "dummy"),
+                            null,
                             null
                     ),
                     is(false)


### PR DESCRIPTION
This PR intends to fix [JENKINS-38552](https://issues.jenkins-ci.org/browse/JENKINS-38552)

This PR is dependent of [this PR on branch-api-plugin](https://github.com/jenkinsci/branch-api-plugin/pull/144)

The idea is to not build on the first branch indexing as in a real enterprise context this might produce dozens/hundreds of agents to start builds, which I don't see why they are necessary - from the little I saw on the code.