### PR TITLE
[JENKINS-38552] Sync with branch-api to use lastSeenRevision + lastBuilt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,8 +94,8 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>branch-api</artifactId>
-      <!-- <version>2.4.1-SNAPSHOT-fbelzunc</version> -->
-      <version>2.4.1-rc719.c05920477cc2</version>
+      <!--<version>2.4.1-SNAPSHOT-fbelzunc</version>-->
+      <version>2.4.1-rc720.fd9bc2162d28</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
   <properties>
     <java.level>8</java.level>
     <jenkins.version>2.107.3</jenkins.version>
-    <scm-api.version>2.4.0</scm-api.version>
+    <scm-api.version>2.4.1</scm-api.version>
   </properties>
 
   <repositories>
@@ -94,7 +94,8 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>branch-api</artifactId>
-      <version>2.3.0</version>
+      <!-- <version>2.4.1-SNAPSHOT-fbelzunc</version> -->
+      <version>2.4.1-rc719.c05920477cc2</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -94,8 +94,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>branch-api</artifactId>
-      <!-- <version>2.4.1-SNAPSHOT-fbelzunc</version> -->
-      <version>2.4.1-rc733.da7fb256b01c</version>
+      <version>2.4.1-rc749.95bebc14892d</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 
   <properties>
     <java.level>8</java.level>
-    <jenkins.version>2.107.3</jenkins.version>
+    <jenkins.version>2.138</jenkins.version>
     <scm-api.version>2.4.1</scm-api.version>
   </properties>
 
@@ -94,8 +94,8 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>branch-api</artifactId>
-      <!--<version>2.4.1-SNAPSHOT-fbelzunc</version>-->
-      <version>2.4.1-rc720.fd9bc2162d28</version>
+      <!-- <version>2.4.1-SNAPSHOT-fbelzunc</version> -->
+      <version>2.4.1-rc733.da7fb256b01c</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl.java
@@ -30,8 +30,10 @@ import hudson.Util;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Level;
 
 import hudson.model.TaskListener;
+import hudson.util.LogTaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
@@ -39,6 +41,8 @@ import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
+
+import static com.sun.xml.internal.ws.spi.db.BindingContextFactory.LOGGER;
 
 /**
  * A {@link BranchBuildStrategy} that builds branches based on the results of all sub strategies matching.
@@ -65,9 +69,27 @@ public class AllBranchBuildStrategyImpl extends BranchBuildStrategy {
     /**
      * {@inheritDoc}
      */
-    @Override
+    @Deprecated
+    public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
+                                    SCMRevision prevRevision) {
+        return isAutomaticBuild(source,head, currRevision, prevRevision, new LogTaskListener(LOGGER, Level.INFO));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Deprecated
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     SCMRevision prevRevision, TaskListener taskListener) {
+        return isAutomaticBuild(source,head, currRevision, prevRevision,  taskListener, null);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
+                                    SCMRevision prevRevision, TaskListener taskListener, SCMRevision lastSeenRevision) {
 
         if(strategies.isEmpty()){
             return false;
@@ -79,7 +101,8 @@ public class AllBranchBuildStrategyImpl extends BranchBuildStrategy {
                 head,
                 currRevision,
                 prevRevision,
-                taskListener
+                taskListener,
+                lastSeenRevision
             )){
                 return false;
             };

--- a/src/main/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl.java
@@ -43,6 +43,8 @@ import jenkins.scm.api.SCMSource;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import javax.annotation.CheckForNull;
+
 /**
  * A {@link BranchBuildStrategy} that builds branches based on the results of all sub strategies matching.
  *
@@ -70,7 +72,7 @@ public class AllBranchBuildStrategyImpl extends BranchBuildStrategy {
      */
     @Deprecated
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision prevRevision) {
+                                    @CheckForNull SCMRevision prevRevision) {
         return isAutomaticBuild(source,head, currRevision, prevRevision, new LogTaskListener(Logger.getLogger(getClass().getName()), Level.INFO));
     }
 
@@ -79,7 +81,7 @@ public class AllBranchBuildStrategyImpl extends BranchBuildStrategy {
      */
     @Deprecated
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision prevRevision, TaskListener taskListener) {
+                                    @CheckForNull SCMRevision prevRevision, @NonNull TaskListener taskListener) {
         return isAutomaticBuild(source,head, currRevision, prevRevision, prevRevision, taskListener);
     }
 
@@ -88,7 +90,7 @@ public class AllBranchBuildStrategyImpl extends BranchBuildStrategy {
      */
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
+                                    @CheckForNull SCMRevision lastBuiltRevision, @CheckForNull SCMRevision lastSeenRevision, @NonNull TaskListener taskListener) {
 
         if(strategies.isEmpty()){
             return false;

--- a/src/main/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.logging.Level;
 
 import hudson.model.TaskListener;
-import hudson.util.LogTaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
@@ -41,8 +40,6 @@ import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-
-import static com.sun.xml.internal.ws.spi.db.BindingContextFactory.LOGGER;
 
 /**
  * A {@link BranchBuildStrategy} that builds branches based on the results of all sub strategies matching.
@@ -72,7 +69,7 @@ public class AllBranchBuildStrategyImpl extends BranchBuildStrategy {
     @Deprecated
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     SCMRevision prevRevision) {
-        return isAutomaticBuild(source,head, currRevision, prevRevision, new LogTaskListener(LOGGER, Level.INFO));
+        return isAutomaticBuild(source,head, currRevision, prevRevision, null);
     }
 
     /**

--- a/src/main/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl.java
@@ -30,7 +30,6 @@ import hudson.Util;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
 
 import hudson.model.TaskListener;
 import jenkins.branch.BranchBuildStrategy;
@@ -78,7 +77,7 @@ public class AllBranchBuildStrategyImpl extends BranchBuildStrategy {
     @Deprecated
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     SCMRevision prevRevision, TaskListener taskListener) {
-        return isAutomaticBuild(source,head, currRevision, prevRevision,  taskListener, null);
+        return isAutomaticBuild(source,head, currRevision, prevRevision, prevRevision, taskListener);
     }
 
     /**
@@ -86,7 +85,7 @@ public class AllBranchBuildStrategyImpl extends BranchBuildStrategy {
      */
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision prevRevision, TaskListener taskListener, SCMRevision lastSeenRevision) {
+                                    SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
 
         if(strategies.isEmpty()){
             return false;
@@ -97,9 +96,9 @@ public class AllBranchBuildStrategyImpl extends BranchBuildStrategy {
                 source,
                 head,
                 currRevision,
-                prevRevision,
-                taskListener,
-                lastSeenRevision
+                lastBuiltRevision,
+                lastSeenRevision,
+                taskListener
             )){
                 return false;
             };

--- a/src/main/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl.java
@@ -30,8 +30,11 @@ import hudson.Util;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import hudson.model.TaskListener;
+import hudson.util.LogTaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
@@ -68,7 +71,7 @@ public class AllBranchBuildStrategyImpl extends BranchBuildStrategy {
     @Deprecated
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     SCMRevision prevRevision) {
-        return isAutomaticBuild(source,head, currRevision, prevRevision, null);
+        return isAutomaticBuild(source,head, currRevision, prevRevision, new LogTaskListener(Logger.getLogger(getClass().getName()), Level.INFO));
     }
 
     /**

--- a/src/main/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl.java
@@ -27,7 +27,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.TaskListener;
-import hudson.util.LogTaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
@@ -40,8 +39,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
-
-import static com.sun.xml.internal.ws.spi.db.BindingContextFactory.LOGGER;
 
 /**
  * A {@link BranchBuildStrategy} that builds branches based on the results of any sub strategy matching.
@@ -72,7 +69,7 @@ public class AnyBranchBuildStrategyImpl extends BranchBuildStrategy {
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     SCMRevision prevRevision) {
-        return isAutomaticBuild(source, head, currRevision, prevRevision, new LogTaskListener(LOGGER, Level.INFO));
+        return isAutomaticBuild(source, head, currRevision, prevRevision, null);
     }
 
     /**

--- a/src/main/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl.java
@@ -38,7 +38,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
 
 /**
  * A {@link BranchBuildStrategy} that builds branches based on the results of any sub strategy matching.
@@ -79,7 +78,7 @@ public class AnyBranchBuildStrategyImpl extends BranchBuildStrategy {
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     SCMRevision prevRevision, TaskListener taskListener) {
-        return isAutomaticBuild(source, head, currRevision, prevRevision, taskListener, null);
+        return isAutomaticBuild(source,head, currRevision, prevRevision, prevRevision, taskListener);
     }
 
     /**
@@ -87,7 +86,7 @@ public class AnyBranchBuildStrategyImpl extends BranchBuildStrategy {
      */
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision prevRevision, TaskListener taskListener, SCMRevision lastSeenRevision) {
+                                    SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
 
         if(strategies.isEmpty()){
             return false;
@@ -98,9 +97,9 @@ public class AnyBranchBuildStrategyImpl extends BranchBuildStrategy {
                 source,
                 head,
                 currRevision,
-                prevRevision,
-                taskListener,
-                lastSeenRevision
+                lastBuiltRevision,
+                lastSeenRevision,
+                taskListener
             )){
                 return true;
             };

--- a/src/main/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl.java
@@ -27,6 +27,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.TaskListener;
+import hudson.util.LogTaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
@@ -38,6 +39,8 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * A {@link BranchBuildStrategy} that builds branches based on the results of any sub strategy matching.
@@ -68,7 +71,7 @@ public class AnyBranchBuildStrategyImpl extends BranchBuildStrategy {
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     SCMRevision prevRevision) {
-        return isAutomaticBuild(source, head, currRevision, prevRevision, null);
+        return isAutomaticBuild(source, head, currRevision, prevRevision, new LogTaskListener(Logger.getLogger(getClass().getName()), Level.INFO));
     }
 
     /**

--- a/src/main/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl.java
@@ -27,6 +27,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.TaskListener;
+import hudson.util.LogTaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
@@ -38,6 +39,9 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Level;
+
+import static com.sun.xml.internal.ws.spi.db.BindingContextFactory.LOGGER;
 
 /**
  * A {@link BranchBuildStrategy} that builds branches based on the results of any sub strategy matching.
@@ -64,9 +68,29 @@ public class AnyBranchBuildStrategyImpl extends BranchBuildStrategy {
     /**
      * {@inheritDoc}
      */
+    @Deprecated
+    @Override
+    public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
+                                    SCMRevision prevRevision) {
+        return isAutomaticBuild(source, head, currRevision, prevRevision, new LogTaskListener(LOGGER, Level.INFO));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Deprecated
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     SCMRevision prevRevision, TaskListener taskListener) {
+        return isAutomaticBuild(source, head, currRevision, prevRevision, taskListener, null);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
+                                    SCMRevision prevRevision, TaskListener taskListener, SCMRevision lastSeenRevision) {
 
         if(strategies.isEmpty()){
             return false;
@@ -78,7 +102,8 @@ public class AnyBranchBuildStrategyImpl extends BranchBuildStrategy {
                 head,
                 currRevision,
                 prevRevision,
-                taskListener
+                taskListener,
+                lastSeenRevision
             )){
                 return true;
             };

--- a/src/main/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl.java
@@ -36,6 +36,7 @@ import jenkins.scm.api.SCMSource;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import javax.annotation.CheckForNull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -70,7 +71,7 @@ public class AnyBranchBuildStrategyImpl extends BranchBuildStrategy {
     @Deprecated
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision prevRevision) {
+                                    @CheckForNull SCMRevision prevRevision) {
         return isAutomaticBuild(source, head, currRevision, prevRevision, new LogTaskListener(Logger.getLogger(getClass().getName()), Level.INFO));
     }
 
@@ -80,7 +81,7 @@ public class AnyBranchBuildStrategyImpl extends BranchBuildStrategy {
     @Deprecated
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision prevRevision, TaskListener taskListener) {
+                                    @CheckForNull SCMRevision prevRevision, @NonNull TaskListener taskListener) {
         return isAutomaticBuild(source,head, currRevision, prevRevision, prevRevision, taskListener);
     }
 
@@ -89,7 +90,7 @@ public class AnyBranchBuildStrategyImpl extends BranchBuildStrategy {
      */
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
+                                    @CheckForNull SCMRevision lastBuiltRevision, @CheckForNull SCMRevision lastSeenRevision, @NonNull TaskListener taskListener) {
 
         if(strategies.isEmpty()){
             return false;

--- a/src/main/java/jenkins/branch/buildstrategies/basic/BranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/BranchBuildStrategyImpl.java
@@ -26,7 +26,6 @@ package jenkins.branch.buildstrategies.basic;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.TaskListener;
-import hudson.util.LogTaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
@@ -38,8 +37,6 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.util.logging.Level;
-
-import static com.sun.xml.internal.ws.spi.db.BindingContextFactory.LOGGER;
 
 /**
  * A {@link BranchBuildStrategy} that builds things that are neither tags nor change requests.
@@ -61,7 +58,7 @@ public class BranchBuildStrategyImpl extends BranchBuildStrategy {
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     SCMRevision prevRevision) {
-        return isAutomaticBuild(source, head, currRevision, prevRevision, new LogTaskListener(LOGGER, Level.INFO));
+        return isAutomaticBuild(source, head, currRevision, prevRevision, null);
     }
 
     /**

--- a/src/main/java/jenkins/branch/buildstrategies/basic/BranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/BranchBuildStrategyImpl.java
@@ -36,7 +36,6 @@ import jenkins.scm.api.mixin.TagSCMHead;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-
 /**
  * A {@link BranchBuildStrategy} that builds things that are neither tags nor change requests.
  *

--- a/src/main/java/jenkins/branch/buildstrategies/basic/BranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/BranchBuildStrategyImpl.java
@@ -26,6 +26,7 @@ package jenkins.branch.buildstrategies.basic;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.TaskListener;
+import hudson.util.LogTaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
@@ -35,6 +36,10 @@ import jenkins.scm.api.mixin.ChangeRequestSCMHead;
 import jenkins.scm.api.mixin.TagSCMHead;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.util.logging.Level;
+
+import static com.sun.xml.internal.ws.spi.db.BindingContextFactory.LOGGER;
 
 /**
  * A {@link BranchBuildStrategy} that builds things that are neither tags nor change requests.
@@ -52,9 +57,29 @@ public class BranchBuildStrategyImpl extends BranchBuildStrategy {
     /**
      * {@inheritDoc}
      */
+    @Deprecated
+    @Override
+    public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
+                                    SCMRevision prevRevision) {
+        return isAutomaticBuild(source, head, currRevision, prevRevision, new LogTaskListener(LOGGER, Level.INFO));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Deprecated
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     SCMRevision prevRevision, TaskListener taskListener) {
+        return isAutomaticBuild(source, head, currRevision, prevRevision, taskListener, null);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
+                                    SCMRevision prevRevision, TaskListener taskListener, SCMRevision lastSeenRevision) {
         if (head instanceof ChangeRequestSCMHead) {
             return false;
         }

--- a/src/main/java/jenkins/branch/buildstrategies/basic/BranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/BranchBuildStrategyImpl.java
@@ -36,7 +36,6 @@ import jenkins.scm.api.mixin.TagSCMHead;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import java.util.logging.Level;
 
 /**
  * A {@link BranchBuildStrategy} that builds things that are neither tags nor change requests.
@@ -68,7 +67,7 @@ public class BranchBuildStrategyImpl extends BranchBuildStrategy {
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     SCMRevision prevRevision, TaskListener taskListener) {
-        return isAutomaticBuild(source, head, currRevision, prevRevision, taskListener, null);
+        return isAutomaticBuild(source,head, currRevision, prevRevision, prevRevision, taskListener);
     }
 
     /**
@@ -76,7 +75,7 @@ public class BranchBuildStrategyImpl extends BranchBuildStrategy {
      */
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision prevRevision, TaskListener taskListener, SCMRevision lastSeenRevision) {
+                                    SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
         if (head instanceof ChangeRequestSCMHead) {
             return false;
         }

--- a/src/main/java/jenkins/branch/buildstrategies/basic/BranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/BranchBuildStrategyImpl.java
@@ -26,6 +26,7 @@ package jenkins.branch.buildstrategies.basic;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.TaskListener;
+import hudson.util.LogTaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
@@ -35,6 +36,9 @@ import jenkins.scm.api.mixin.ChangeRequestSCMHead;
 import jenkins.scm.api.mixin.TagSCMHead;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * A {@link BranchBuildStrategy} that builds things that are neither tags nor change requests.
@@ -56,7 +60,7 @@ public class BranchBuildStrategyImpl extends BranchBuildStrategy {
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     SCMRevision prevRevision) {
-        return isAutomaticBuild(source, head, currRevision, prevRevision, null);
+        return isAutomaticBuild(source, head, currRevision, prevRevision, new LogTaskListener(Logger.getLogger(getClass().getName()), Level.INFO));
     }
 
     /**

--- a/src/main/java/jenkins/branch/buildstrategies/basic/BranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/BranchBuildStrategyImpl.java
@@ -37,6 +37,7 @@ import jenkins.scm.api.mixin.TagSCMHead;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import javax.annotation.CheckForNull;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -59,7 +60,7 @@ public class BranchBuildStrategyImpl extends BranchBuildStrategy {
     @Deprecated
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision prevRevision) {
+                                    @CheckForNull SCMRevision prevRevision) {
         return isAutomaticBuild(source, head, currRevision, prevRevision, new LogTaskListener(Logger.getLogger(getClass().getName()), Level.INFO));
     }
 
@@ -69,7 +70,7 @@ public class BranchBuildStrategyImpl extends BranchBuildStrategy {
     @Deprecated
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision prevRevision, TaskListener taskListener) {
+                                    @CheckForNull SCMRevision prevRevision, @NonNull TaskListener taskListener) {
         return isAutomaticBuild(source,head, currRevision, prevRevision, prevRevision, taskListener);
     }
 
@@ -78,7 +79,7 @@ public class BranchBuildStrategyImpl extends BranchBuildStrategy {
      */
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
+                                    @CheckForNull SCMRevision lastBuiltRevision, @CheckForNull SCMRevision lastSeenRevision, @NonNull TaskListener taskListener) {
         if (head instanceof ChangeRequestSCMHead) {
             return false;
         }

--- a/src/main/java/jenkins/branch/buildstrategies/basic/ChangeRequestBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/ChangeRequestBuildStrategyImpl.java
@@ -112,7 +112,7 @@ public class ChangeRequestBuildStrategyImpl extends BranchBuildStrategy {
     @Deprecated
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    @CheckForNull SCMRevision prevRevision, TaskListener taskListener) {
+                                    @CheckForNull SCMRevision prevRevision, @NonNull TaskListener taskListener) {
         return isAutomaticBuild(source,head, currRevision, prevRevision, prevRevision, taskListener);
     }
 
@@ -122,7 +122,7 @@ public class ChangeRequestBuildStrategyImpl extends BranchBuildStrategy {
     @Restricted(ProtectedExternally.class)
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener listener) {
+                                    @CheckForNull SCMRevision lastBuiltRevision, @CheckForNull SCMRevision lastSeenRevision, @NonNull TaskListener listener) {
         if (!(head instanceof ChangeRequestSCMHead)) {
             return false;
         }

--- a/src/main/java/jenkins/branch/buildstrategies/basic/ChangeRequestBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/ChangeRequestBuildStrategyImpl.java
@@ -45,6 +45,8 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.ProtectedExternally;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import static com.sun.xml.internal.ws.spi.db.BindingContextFactory.LOGGER;
+
 /**
  * A {@link BranchBuildStrategy} that builds change requests.
  *
@@ -108,9 +110,43 @@ public class ChangeRequestBuildStrategyImpl extends BranchBuildStrategy {
      * {@inheritDoc}
      */
     @Restricted(ProtectedExternally.class)
+    @Deprecated
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     @CheckForNull SCMRevision prevRevision, TaskListener listener) {
+        if (!(head instanceof ChangeRequestSCMHead)) {
+            return false;
+        }
+        if (ignoreTargetOnlyChanges
+                && currRevision instanceof ChangeRequestSCMRevision
+                && prevRevision instanceof ChangeRequestSCMRevision) {
+            ChangeRequestSCMRevision<?> curr = (ChangeRequestSCMRevision<?>) currRevision;
+            if (curr.isMerge() && curr.equivalent((ChangeRequestSCMRevision<?>) prevRevision)) {
+                return false;
+            }
+        }
+        try {
+            if (ignoreUntrustedChanges && !currRevision.equals(source.getTrustedRevision(currRevision, listener))) {
+                return false;
+            }
+        } catch (IOException | InterruptedException e) {
+            LogRecord lr = new LogRecord(Level.WARNING,
+                    "Could not determine trust status for revision {0} of {1}, assuming untrusted");
+            lr.setParameters(new Object[] {currRevision, head});
+            lr.setThrown(e);
+            Functions.printLogRecord(lr);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Restricted(ProtectedExternally.class)
+    @Override
+    public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
+                                    @CheckForNull SCMRevision prevRevision, TaskListener listener, SCMRevision lastSeenRevision) {
         if (!(head instanceof ChangeRequestSCMHead)) {
             return false;
         }

--- a/src/main/java/jenkins/branch/buildstrategies/basic/ChangeRequestBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/ChangeRequestBuildStrategyImpl.java
@@ -32,6 +32,8 @@ import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
+
+import hudson.util.LogTaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
@@ -100,7 +102,7 @@ public class ChangeRequestBuildStrategyImpl extends BranchBuildStrategy {
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     @CheckForNull SCMRevision prevRevision) {
-        return isAutomaticBuild(source, head, currRevision, prevRevision, null);
+        return isAutomaticBuild(source, head, currRevision, prevRevision, new LogTaskListener(Logger.getLogger(getClass().getName()), Level.INFO));
     }
 
     /**

--- a/src/main/java/jenkins/branch/buildstrategies/basic/ChangeRequestBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/ChangeRequestBuildStrategyImpl.java
@@ -110,31 +110,8 @@ public class ChangeRequestBuildStrategyImpl extends BranchBuildStrategy {
     @Deprecated
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    @CheckForNull SCMRevision prevRevision, TaskListener listener) {
-        if (!(head instanceof ChangeRequestSCMHead)) {
-            return false;
-        }
-        if (ignoreTargetOnlyChanges
-                && currRevision instanceof ChangeRequestSCMRevision
-                && prevRevision instanceof ChangeRequestSCMRevision) {
-            ChangeRequestSCMRevision<?> curr = (ChangeRequestSCMRevision<?>) currRevision;
-            if (curr.isMerge() && curr.equivalent((ChangeRequestSCMRevision<?>) prevRevision)) {
-                return false;
-            }
-        }
-        try {
-            if (ignoreUntrustedChanges && !currRevision.equals(source.getTrustedRevision(currRevision, listener))) {
-                return false;
-            }
-        } catch (IOException | InterruptedException e) {
-            LogRecord lr = new LogRecord(Level.WARNING,
-                    "Could not determine trust status for revision {0} of {1}, assuming untrusted");
-            lr.setParameters(new Object[] {currRevision, head});
-            lr.setThrown(e);
-            Functions.printLogRecord(lr);
-            return false;
-        }
-        return true;
+                                    @CheckForNull SCMRevision prevRevision, TaskListener taskListener) {
+        return isAutomaticBuild(source,head, currRevision, prevRevision, prevRevision, taskListener);
     }
 
     /**
@@ -143,15 +120,15 @@ public class ChangeRequestBuildStrategyImpl extends BranchBuildStrategy {
     @Restricted(ProtectedExternally.class)
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    @CheckForNull SCMRevision prevRevision, TaskListener listener, SCMRevision lastSeenRevision) {
+                                    SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener listener) {
         if (!(head instanceof ChangeRequestSCMHead)) {
             return false;
         }
         if (ignoreTargetOnlyChanges
                 && currRevision instanceof ChangeRequestSCMRevision
-                && prevRevision instanceof ChangeRequestSCMRevision) {
+                && lastBuiltRevision instanceof ChangeRequestSCMRevision) {
             ChangeRequestSCMRevision<?> curr = (ChangeRequestSCMRevision<?>) currRevision;
-            if (curr.isMerge() && curr.equivalent((ChangeRequestSCMRevision<?>) prevRevision)) {
+            if (curr.isMerge() && curr.equivalent((ChangeRequestSCMRevision<?>) lastBuiltRevision)) {
                 return false;
             }
         }

--- a/src/main/java/jenkins/branch/buildstrategies/basic/ChangeRequestBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/ChangeRequestBuildStrategyImpl.java
@@ -28,7 +28,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Functions;
 import hudson.model.TaskListener;
-import hudson.util.LogTaskListener;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -44,8 +43,6 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.ProtectedExternally;
 import org.kohsuke.stapler.DataBoundConstructor;
-
-import static com.sun.xml.internal.ws.spi.db.BindingContextFactory.LOGGER;
 
 /**
  * A {@link BranchBuildStrategy} that builds change requests.
@@ -103,7 +100,7 @@ public class ChangeRequestBuildStrategyImpl extends BranchBuildStrategy {
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     @CheckForNull SCMRevision prevRevision) {
-        return isAutomaticBuild(source, head, currRevision, prevRevision, new LogTaskListener(LOGGER, Level.INFO));
+        return isAutomaticBuild(source, head, currRevision, prevRevision, null);
     }
 
     /**

--- a/src/main/java/jenkins/branch/buildstrategies/basic/NamedBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/NamedBranchBuildStrategyImpl.java
@@ -34,9 +34,13 @@ import hudson.util.FormValidation;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import javax.annotation.Nonnull;
+
+import hudson.util.LogTaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
@@ -80,7 +84,7 @@ public class NamedBranchBuildStrategyImpl extends BranchBuildStrategy {
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     SCMRevision prevRevision) {
-        return isAutomaticBuild(source, head, currRevision, prevRevision, null);
+        return isAutomaticBuild(source, head, currRevision, prevRevision, new LogTaskListener(Logger.getLogger(getClass().getName()), Level.INFO));
     }
 
     /**

--- a/src/main/java/jenkins/branch/buildstrategies/basic/NamedBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/NamedBranchBuildStrategyImpl.java
@@ -83,7 +83,7 @@ public class NamedBranchBuildStrategyImpl extends BranchBuildStrategy {
     @Deprecated
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision prevRevision) {
+                                    @CheckForNull SCMRevision prevRevision) {
         return isAutomaticBuild(source, head, currRevision, prevRevision, new LogTaskListener(Logger.getLogger(getClass().getName()), Level.INFO));
     }
 
@@ -93,7 +93,7 @@ public class NamedBranchBuildStrategyImpl extends BranchBuildStrategy {
     @Deprecated
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision prevRevision, TaskListener taskListener) {
+                                    @CheckForNull SCMRevision prevRevision, @NonNull TaskListener taskListener) {
         return isAutomaticBuild(source,head, currRevision, prevRevision, prevRevision, taskListener);
     }
 
@@ -102,7 +102,7 @@ public class NamedBranchBuildStrategyImpl extends BranchBuildStrategy {
      */
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
+                                    @CheckForNull SCMRevision lastBuiltRevision, @CheckForNull SCMRevision lastSeenRevision, @NonNull TaskListener taskListener) {
         if (head instanceof ChangeRequestSCMHead) {
             return false;
         }

--- a/src/main/java/jenkins/branch/buildstrategies/basic/NamedBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/NamedBranchBuildStrategyImpl.java
@@ -39,7 +39,6 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import javax.annotation.Nonnull;
 
-import hudson.util.LogTaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
@@ -53,8 +52,6 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
-
-import static com.sun.xml.internal.ws.spi.db.BindingContextFactory.LOGGER;
 
 /**
  * A {@link BranchBuildStrategy} that builds branches with specific names.
@@ -85,7 +82,7 @@ public class NamedBranchBuildStrategyImpl extends BranchBuildStrategy {
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     SCMRevision prevRevision) {
-        return isAutomaticBuild(source, head, currRevision, prevRevision, new LogTaskListener(LOGGER, Level.INFO));
+        return isAutomaticBuild(source, head, currRevision, prevRevision, null);
     }
 
     /**

--- a/src/main/java/jenkins/branch/buildstrategies/basic/NamedBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/NamedBranchBuildStrategyImpl.java
@@ -34,9 +34,12 @@ import hudson.util.FormValidation;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import javax.annotation.Nonnull;
+
+import hudson.util.LogTaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
@@ -50,6 +53,8 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
+
+import static com.sun.xml.internal.ws.spi.db.BindingContextFactory.LOGGER;
 
 /**
  * A {@link BranchBuildStrategy} that builds branches with specific names.
@@ -76,9 +81,29 @@ public class NamedBranchBuildStrategyImpl extends BranchBuildStrategy {
     /**
      * {@inheritDoc}
      */
+    @Deprecated
+    @Override
+    public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
+                                    SCMRevision prevRevision) {
+        return isAutomaticBuild(source, head, currRevision, prevRevision, new LogTaskListener(LOGGER, Level.INFO));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Deprecated
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     SCMRevision prevRevision, TaskListener taskListener) {
+        return isAutomaticBuild(source, head, currRevision, prevRevision, taskListener, null);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
+                                    SCMRevision prevRevision, TaskListener taskListener, SCMRevision lastSeenRevision) {
         if (head instanceof ChangeRequestSCMHead) {
             return false;
         }

--- a/src/main/java/jenkins/branch/buildstrategies/basic/NamedBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/NamedBranchBuildStrategyImpl.java
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import javax.annotation.Nonnull;
-
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;

--- a/src/main/java/jenkins/branch/buildstrategies/basic/NamedBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/NamedBranchBuildStrategyImpl.java
@@ -34,7 +34,6 @@ import hudson.util.FormValidation;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import javax.annotation.Nonnull;
@@ -92,7 +91,7 @@ public class NamedBranchBuildStrategyImpl extends BranchBuildStrategy {
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     SCMRevision prevRevision, TaskListener taskListener) {
-        return isAutomaticBuild(source, head, currRevision, prevRevision, taskListener, null);
+        return isAutomaticBuild(source,head, currRevision, prevRevision, prevRevision, taskListener);
     }
 
     /**
@@ -100,7 +99,7 @@ public class NamedBranchBuildStrategyImpl extends BranchBuildStrategy {
      */
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision prevRevision, TaskListener taskListener, SCMRevision lastSeenRevision) {
+                                    SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
         if (head instanceof ChangeRequestSCMHead) {
             return false;
         }

--- a/src/main/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl.java
@@ -27,6 +27,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.TaskListener;
+import hudson.util.LogTaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
@@ -38,6 +39,9 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Level;
+
+import static com.sun.xml.internal.ws.spi.db.BindingContextFactory.LOGGER;
 
 /**
  * A {@link BranchBuildStrategy} that builds branches based on the results of all sub strategy NOT matching.
@@ -64,9 +68,29 @@ public class NoneBranchBuildStrategyImpl extends BranchBuildStrategy {
     /**
      * {@inheritDoc}
      */
+    @Deprecated
+    @Override
+    public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
+                                    SCMRevision prevRevision) {
+        return isAutomaticBuild(source, head, currRevision, prevRevision, new LogTaskListener(LOGGER, Level.INFO));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Deprecated
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     SCMRevision prevRevision, TaskListener taskListener) {
+        return isAutomaticBuild(source, head, currRevision, prevRevision, taskListener, null);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
+                                    SCMRevision prevRevision, TaskListener taskListener, SCMRevision lastSeenRevision) {
 
         if(strategies.isEmpty()){
             return false;
@@ -78,7 +102,8 @@ public class NoneBranchBuildStrategyImpl extends BranchBuildStrategy {
                 head,
                 currRevision,
                 prevRevision,
-                    taskListener
+                    taskListener,
+                lastSeenRevision
             )){
                 return false;
             };

--- a/src/main/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl.java
@@ -36,6 +36,7 @@ import jenkins.scm.api.SCMSource;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import javax.annotation.CheckForNull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -70,7 +71,7 @@ public class NoneBranchBuildStrategyImpl extends BranchBuildStrategy {
     @Deprecated
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision prevRevision) {
+                                    @CheckForNull SCMRevision prevRevision) {
         return isAutomaticBuild(source, head, currRevision, prevRevision, new LogTaskListener(Logger.getLogger(getClass().getName()), Level.INFO));
     }
 
@@ -80,7 +81,7 @@ public class NoneBranchBuildStrategyImpl extends BranchBuildStrategy {
     @Deprecated
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision prevRevision, TaskListener taskListener) {
+                                    @CheckForNull SCMRevision prevRevision, @NonNull TaskListener taskListener) {
         return isAutomaticBuild(source,head, currRevision, prevRevision, prevRevision, taskListener);
     }
 
@@ -89,7 +90,7 @@ public class NoneBranchBuildStrategyImpl extends BranchBuildStrategy {
      */
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
+                                    @CheckForNull SCMRevision lastBuiltRevision, @CheckForNull SCMRevision lastSeenRevision, @NonNull TaskListener taskListener) {
 
         if(strategies.isEmpty()){
             return false;

--- a/src/main/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl.java
@@ -103,6 +103,7 @@ public class NoneBranchBuildStrategyImpl extends BranchBuildStrategy {
             )){
                 return false;
             };
+
         }
         return true;
     }

--- a/src/main/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl.java
@@ -27,6 +27,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.TaskListener;
+import hudson.util.LogTaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
@@ -38,6 +39,8 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * A {@link BranchBuildStrategy} that builds branches based on the results of all sub strategy NOT matching.
@@ -68,7 +71,7 @@ public class NoneBranchBuildStrategyImpl extends BranchBuildStrategy {
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     SCMRevision prevRevision) {
-        return isAutomaticBuild(source, head, currRevision, prevRevision, null);
+        return isAutomaticBuild(source, head, currRevision, prevRevision, new LogTaskListener(Logger.getLogger(getClass().getName()), Level.INFO));
     }
 
     /**

--- a/src/main/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl.java
@@ -27,7 +27,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.TaskListener;
-import hudson.util.LogTaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
@@ -40,8 +39,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
-
-import static com.sun.xml.internal.ws.spi.db.BindingContextFactory.LOGGER;
 
 /**
  * A {@link BranchBuildStrategy} that builds branches based on the results of all sub strategy NOT matching.
@@ -72,7 +69,7 @@ public class NoneBranchBuildStrategyImpl extends BranchBuildStrategy {
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     SCMRevision prevRevision) {
-        return isAutomaticBuild(source, head, currRevision, prevRevision, new LogTaskListener(LOGGER, Level.INFO));
+        return isAutomaticBuild(source, head, currRevision, prevRevision, null);
     }
 
     /**

--- a/src/main/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl.java
@@ -38,7 +38,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
 
 /**
  * A {@link BranchBuildStrategy} that builds branches based on the results of all sub strategy NOT matching.
@@ -79,7 +78,7 @@ public class NoneBranchBuildStrategyImpl extends BranchBuildStrategy {
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     SCMRevision prevRevision, TaskListener taskListener) {
-        return isAutomaticBuild(source, head, currRevision, prevRevision, taskListener, null);
+        return isAutomaticBuild(source,head, currRevision, prevRevision, prevRevision, taskListener);
     }
 
     /**
@@ -87,7 +86,7 @@ public class NoneBranchBuildStrategyImpl extends BranchBuildStrategy {
      */
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision prevRevision, TaskListener taskListener, SCMRevision lastSeenRevision) {
+                                    SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
 
         if(strategies.isEmpty()){
             return false;
@@ -98,13 +97,12 @@ public class NoneBranchBuildStrategyImpl extends BranchBuildStrategy {
                 source,
                 head,
                 currRevision,
-                prevRevision,
-                    taskListener,
-                lastSeenRevision
+                lastBuiltRevision,
+                lastSeenRevision,
+                taskListener
             )){
                 return false;
             };
-
         }
         return true;
     }

--- a/src/main/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexing.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexing.java
@@ -35,6 +35,8 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import javax.annotation.CheckForNull;
+
 
 @Restricted(NoExternalUse.class)
 @Extension
@@ -50,7 +52,7 @@ public class SkipInitialBuildOnFirstBranchIndexing extends BranchBuildStrategy {
      */
     @Deprecated
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision prevRevision, TaskListener taskListener) {
+                                    @CheckForNull SCMRevision prevRevision, TaskListener taskListener) {
         return isAutomaticBuild(source,head, currRevision, prevRevision, prevRevision, taskListener);
     }
 
@@ -59,7 +61,7 @@ public class SkipInitialBuildOnFirstBranchIndexing extends BranchBuildStrategy {
      */
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
+                                    @CheckForNull SCMRevision lastBuiltRevision, @CheckForNull SCMRevision lastSeenRevision, @NonNull TaskListener taskListener) {
         if (lastSeenRevision != null) {
             return true;
         }

--- a/src/main/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexing.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexing.java
@@ -45,8 +45,21 @@ public class SkipInitialBuildOnFirstBranchIndexing extends BranchBuildStrategy {
 
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Deprecated
+    public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
+                                    SCMRevision prevRevision, TaskListener taskListener) {
+        return isAutomaticBuild(source,head, currRevision, prevRevision, prevRevision, taskListener);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision currRevision, SCMRevision prevRevision, TaskListener taskListener, SCMRevision lastSeenRevision) {
+    public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
+                                    SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
         if (lastSeenRevision != null) {
             return true;
         }

--- a/src/main/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexing.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexing.java
@@ -46,8 +46,8 @@ public class SkipInitialBuildOnFirstBranchIndexing extends BranchBuildStrategy {
     }
 
     @Override
-    public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision currRevision, SCMRevision prevRevision, TaskListener taskListener) {
-        if (prevRevision != null) {
+    public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision currRevision, SCMRevision prevRevision, TaskListener taskListener, SCMRevision lastSeenRevision) {
+        if (lastSeenRevision != null) {
             return true;
         }
         return false;

--- a/src/main/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImpl.java
@@ -28,8 +28,11 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import hudson.model.TaskListener;
+import hudson.util.LogTaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
@@ -118,7 +121,7 @@ public class TagBuildStrategyImpl extends BranchBuildStrategy {
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     SCMRevision prevRevision) {
-        return isAutomaticBuild(source, head, currRevision, prevRevision, null);
+        return isAutomaticBuild(source, head, currRevision, prevRevision, new LogTaskListener(Logger.getLogger(getClass().getName()), Level.INFO));
     }
 
     /**

--- a/src/main/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImpl.java
@@ -120,7 +120,7 @@ public class TagBuildStrategyImpl extends BranchBuildStrategy {
     @Deprecated
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision prevRevision) {
+                                    @CheckForNull SCMRevision prevRevision) {
         return isAutomaticBuild(source, head, currRevision, prevRevision, new LogTaskListener(Logger.getLogger(getClass().getName()), Level.INFO));
     }
 
@@ -130,7 +130,7 @@ public class TagBuildStrategyImpl extends BranchBuildStrategy {
     @Deprecated
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision prevRevision, TaskListener taskListener) {
+                                    @CheckForNull SCMRevision prevRevision, @NonNull  TaskListener taskListener) {
         return isAutomaticBuild(source,head, currRevision, prevRevision, prevRevision, taskListener);
     }
 
@@ -139,7 +139,7 @@ public class TagBuildStrategyImpl extends BranchBuildStrategy {
      */
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
+                                    @CheckForNull SCMRevision lastBuiltRevision, @CheckForNull SCMRevision lastSeenRevision, @NonNull  TaskListener taskListener) {
         if (!(head instanceof TagSCMHead)) {
             return false;
         }

--- a/src/main/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImpl.java
@@ -28,8 +28,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 
 import hudson.model.TaskListener;
+import hudson.util.LogTaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
@@ -42,6 +44,8 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.stapler.DataBoundConstructor;
+
+import static com.sun.xml.internal.ws.spi.db.BindingContextFactory.LOGGER;
 
 /**
  * A {@link BranchBuildStrategy} that builds tags.
@@ -114,9 +118,29 @@ public class TagBuildStrategyImpl extends BranchBuildStrategy {
     /**
      * {@inheritDoc}
      */
+    @Deprecated
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    @CheckForNull SCMRevision prevRevision, TaskListener taskListener) {
+                                    SCMRevision prevRevision) {
+        return isAutomaticBuild(source, head, currRevision, prevRevision, new LogTaskListener(LOGGER, Level.INFO));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Deprecated
+    @Override
+    public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
+                                    SCMRevision prevRevision, TaskListener taskListener) {
+        return isAutomaticBuild(source, head, currRevision, prevRevision, taskListener, null);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
+                                    @CheckForNull SCMRevision prevRevision, TaskListener taskListener, SCMRevision lastSeenRevision) {
         if (!(head instanceof TagSCMHead)) {
             return false;
         }

--- a/src/main/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImpl.java
@@ -28,7 +28,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 
 import hudson.model.TaskListener;
 import jenkins.branch.BranchBuildStrategy;
@@ -36,7 +35,6 @@ import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
-import jenkins.scm.api.mixin.ChangeRequestSCMHead;
 import jenkins.scm.api.mixin.TagSCMHead;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
@@ -129,7 +127,7 @@ public class TagBuildStrategyImpl extends BranchBuildStrategy {
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     SCMRevision prevRevision, TaskListener taskListener) {
-        return isAutomaticBuild(source, head, currRevision, prevRevision, taskListener, null);
+        return isAutomaticBuild(source,head, currRevision, prevRevision, prevRevision, taskListener);
     }
 
     /**
@@ -137,7 +135,7 @@ public class TagBuildStrategyImpl extends BranchBuildStrategy {
      */
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
-                                    @CheckForNull SCMRevision prevRevision, TaskListener taskListener, SCMRevision lastSeenRevision) {
+                                    SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
         if (!(head instanceof TagSCMHead)) {
             return false;
         }

--- a/src/main/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImpl.java
@@ -31,7 +31,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
 import hudson.model.TaskListener;
-import hudson.util.LogTaskListener;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
@@ -44,8 +43,6 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.stapler.DataBoundConstructor;
-
-import static com.sun.xml.internal.ws.spi.db.BindingContextFactory.LOGGER;
 
 /**
  * A {@link BranchBuildStrategy} that builds tags.
@@ -122,7 +119,7 @@ public class TagBuildStrategyImpl extends BranchBuildStrategy {
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     SCMRevision prevRevision) {
-        return isAutomaticBuild(source, head, currRevision, prevRevision, new LogTaskListener(LOGGER, Level.INFO));
+        return isAutomaticBuild(source, head, currRevision, prevRevision, null);
     }
 
     /**

--- a/src/main/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImpl.java
@@ -35,6 +35,7 @@ import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.mixin.ChangeRequestSCMHead;
 import jenkins.scm.api.mixin.TagSCMHead;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;

--- a/src/test/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImplTest.java
@@ -54,7 +54,8 @@ public class AllBranchBuildStrategyImplTest {
                     head,
                     new MockSCMRevision(head, "dummy"),
                     null,
-                    null
+                    null,
+                        null
                 ),
                 is(false)
             );
@@ -70,13 +71,13 @@ public class AllBranchBuildStrategyImplTest {
                 new AllBranchBuildStrategyImpl(Arrays.asList(
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
                             return true;
                         }
                     },
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
                             return true;
                         }
                     }
@@ -84,6 +85,7 @@ public class AllBranchBuildStrategyImplTest {
                     new MockSCMSource(c, "dummy"),
                     head,
                     new MockSCMRevision(head, "dummy"),
+                        null,
                         null,
                         null
                 ),
@@ -100,13 +102,13 @@ public class AllBranchBuildStrategyImplTest {
                 new AllBranchBuildStrategyImpl(Arrays.asList(
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
                             return false;
                         }
                     },
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
                             return false;
                         }
                     }
@@ -115,6 +117,7 @@ public class AllBranchBuildStrategyImplTest {
                     head,
                     new MockSCMRevision(head, "dummy"),
                     null,
+                        null,
                         null
                 ),
                 is(false)
@@ -131,13 +134,13 @@ public class AllBranchBuildStrategyImplTest {
                 new AllBranchBuildStrategyImpl(Arrays.asList(
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
                             return false;
                         }
                     },
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
                             fail("strategy evaluation must short circuit");
                             return true;
                         }
@@ -147,7 +150,8 @@ public class AllBranchBuildStrategyImplTest {
                     head,
                     new MockSCMRevision(head, "dummy"),
                     null,
-                    null
+                    null,
+                        null
                 ),
                 is(false)
             );

--- a/src/test/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImplTest.java
@@ -74,6 +74,12 @@ public class AllBranchBuildStrategyImplTest {
                         public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision, SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
                             return true;
                         }
+                    },
+                    new BranchBuildStrategy() {
+                        @Override
+                        public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision, SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
+                            return true;
+                        }
                     }
                 )).isAutomaticBuild(
                     new MockSCMSource(c, "dummy"),
@@ -94,6 +100,12 @@ public class AllBranchBuildStrategyImplTest {
             MockSCMHead head = new MockSCMHead("master");
             assertThat(
                 new AllBranchBuildStrategyImpl(Arrays.asList(
+                    new BranchBuildStrategy() {
+                        @Override
+                        public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision, SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
+                            return false;
+                        }
+                    },
                     new BranchBuildStrategy() {
                         @Override
                         public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision, SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
@@ -124,6 +136,12 @@ public class AllBranchBuildStrategyImplTest {
                         @Override
                         public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision, SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
                             return false;
+                        }
+                    },
+                    new BranchBuildStrategy() {
+                        @Override
+                        public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision, SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
+                            return true;
                         }
                     }
                 )).isAutomaticBuild(

--- a/src/test/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImplTest.java
@@ -71,13 +71,7 @@ public class AllBranchBuildStrategyImplTest {
                 new AllBranchBuildStrategyImpl(Arrays.asList(
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
-                            return true;
-                        }
-                    },
-                    new BranchBuildStrategy() {
-                        @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision, SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
                             return true;
                         }
                     }
@@ -102,13 +96,7 @@ public class AllBranchBuildStrategyImplTest {
                 new AllBranchBuildStrategyImpl(Arrays.asList(
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
-                            return false;
-                        }
-                    },
-                    new BranchBuildStrategy() {
-                        @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision, SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
                             return false;
                         }
                     }
@@ -134,15 +122,8 @@ public class AllBranchBuildStrategyImplTest {
                 new AllBranchBuildStrategyImpl(Arrays.asList(
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision, SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
                             return false;
-                        }
-                    },
-                    new BranchBuildStrategy() {
-                        @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
-                            fail("strategy evaluation must short circuit");
-                            return true;
                         }
                     }
                 )).isAutomaticBuild(

--- a/src/test/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImplTest.java
@@ -55,7 +55,7 @@ public class AllBranchBuildStrategyImplTest {
                     new MockSCMRevision(head, "dummy"),
                     null,
                     null,
-                        null
+                    null
                 ),
                 is(false)
             );
@@ -105,8 +105,8 @@ public class AllBranchBuildStrategyImplTest {
                     head,
                     new MockSCMRevision(head, "dummy"),
                     null,
-                        null,
-                        null
+                    null,
+                    null
                 ),
                 is(false)
             );
@@ -132,7 +132,7 @@ public class AllBranchBuildStrategyImplTest {
                     new MockSCMRevision(head, "dummy"),
                     null,
                     null,
-                        null
+                    null
                 ),
                 is(false)
             );

--- a/src/test/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImplTest.java
@@ -54,6 +54,7 @@ public class AnyBranchBuildStrategyImplTest {
                     head,
                     new MockSCMRevision(head, "dummy"),
                     null,
+                        null,
                         null
                 ),
                 is(false)
@@ -70,13 +71,13 @@ public class AnyBranchBuildStrategyImplTest {
                 new AnyBranchBuildStrategyImpl(Arrays.asList(
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
                             return true;
                         }
                     },
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
                             return true;
                         }
                     }
@@ -85,6 +86,7 @@ public class AnyBranchBuildStrategyImplTest {
                     head,
                     new MockSCMRevision(head, "dummy"),
                     null,
+                        null,
                         null
                 ),
                 is(true)
@@ -100,13 +102,13 @@ public class AnyBranchBuildStrategyImplTest {
                 new AnyBranchBuildStrategyImpl(Arrays.asList(
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
                             return false;
                         }
                     },
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
                             return false;
                         }
                     }
@@ -115,6 +117,7 @@ public class AnyBranchBuildStrategyImplTest {
                     head,
                     new MockSCMRevision(head, "dummy"),
                     null,
+                        null,
                         null
                 ),
                 is(false)
@@ -131,13 +134,13 @@ public class AnyBranchBuildStrategyImplTest {
                 new AnyBranchBuildStrategyImpl(Arrays.asList(
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
                             return true;
                         }
                     },
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
                             fail("strategy evaluation must short circuit");
                             return false;
                         }
@@ -147,7 +150,8 @@ public class AnyBranchBuildStrategyImplTest {
                     head,
                     new MockSCMRevision(head, "dummy"),
                     null,
-                    null
+                    null,
+                        null
                 ),
                 is(true)
             );

--- a/src/test/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImplTest.java
@@ -74,6 +74,12 @@ public class AnyBranchBuildStrategyImplTest {
                         public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision, SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
                             return true;
                         }
+                    },
+                    new BranchBuildStrategy() {
+                        @Override
+                        public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision, SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
+                            return true;
+                        }
                     }
                 )).isAutomaticBuild(
                     new MockSCMSource(c, "dummy"),
@@ -94,6 +100,12 @@ public class AnyBranchBuildStrategyImplTest {
             MockSCMHead head = new MockSCMHead("master");
             assertThat(
                 new AnyBranchBuildStrategyImpl(Arrays.asList(
+                    new BranchBuildStrategy() {
+                        @Override
+                        public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision, SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
+                            return false;
+                        }
+                    },
                     new BranchBuildStrategy() {
                         @Override
                         public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision, SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
@@ -124,6 +136,12 @@ public class AnyBranchBuildStrategyImplTest {
                         @Override
                         public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision, SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
                             return true;
+                        }
+                    },
+                    new BranchBuildStrategy() {
+                        @Override
+                        public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision, SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
+                            return false;
                         }
                     }
                 )).isAutomaticBuild(

--- a/src/test/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImplTest.java
@@ -54,8 +54,8 @@ public class AnyBranchBuildStrategyImplTest {
                     head,
                     new MockSCMRevision(head, "dummy"),
                     null,
-                        null,
-                        null
+                    null,
+                    null
                 ),
                 is(false)
             );
@@ -80,8 +80,8 @@ public class AnyBranchBuildStrategyImplTest {
                     head,
                     new MockSCMRevision(head, "dummy"),
                     null,
-                        null,
-                        null
+                    null,
+                    null
                 ),
                 is(true)
             );
@@ -105,8 +105,8 @@ public class AnyBranchBuildStrategyImplTest {
                     head,
                     new MockSCMRevision(head, "dummy"),
                     null,
-                        null,
-                        null
+                    null,
+                    null
                 ),
                 is(false)
             );
@@ -132,7 +132,7 @@ public class AnyBranchBuildStrategyImplTest {
                     new MockSCMRevision(head, "dummy"),
                     null,
                     null,
-                        null
+                    null
                 ),
                 is(true)
             );

--- a/src/test/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImplTest.java
@@ -71,13 +71,7 @@ public class AnyBranchBuildStrategyImplTest {
                 new AnyBranchBuildStrategyImpl(Arrays.asList(
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
-                            return true;
-                        }
-                    },
-                    new BranchBuildStrategy() {
-                        @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision, SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
                             return true;
                         }
                     }
@@ -102,13 +96,7 @@ public class AnyBranchBuildStrategyImplTest {
                 new AnyBranchBuildStrategyImpl(Arrays.asList(
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
-                            return false;
-                        }
-                    },
-                    new BranchBuildStrategy() {
-                        @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision, SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
                             return false;
                         }
                     }
@@ -134,15 +122,8 @@ public class AnyBranchBuildStrategyImplTest {
                 new AnyBranchBuildStrategyImpl(Arrays.asList(
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision, SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
                             return true;
-                        }
-                    },
-                    new BranchBuildStrategy() {
-                        @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
-                            fail("strategy evaluation must short circuit");
-                            return false;
                         }
                     }
                 )).isAutomaticBuild(

--- a/src/test/java/jenkins/branch/buildstrategies/basic/BranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/BranchBuildStrategyImplTest.java
@@ -48,6 +48,7 @@ public class BranchBuildStrategyImplTest {
                             head,
                             new MockSCMRevision(head, "dummy"),
                             null,
+                            null,
                             null
                     ),
                     is(true)
@@ -64,6 +65,7 @@ public class BranchBuildStrategyImplTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
+                            null,
                             null,
                             null
                     ),
@@ -83,6 +85,7 @@ public class BranchBuildStrategyImplTest {
                             head,
                             new MockChangeRequestSCMRevision(head,
                                     new MockSCMRevision(new MockSCMHead("master"), "dummy"), "dummy"),
+                            null,
                             null,
                             null
                     ),

--- a/src/test/java/jenkins/branch/buildstrategies/basic/ChangeRequestBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/ChangeRequestBuildStrategyImplTest.java
@@ -51,6 +51,8 @@ public class ChangeRequestBuildStrategyImplTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
+                            null,
+                            null,
                             null
                     ),
                     is(false)
@@ -67,6 +69,8 @@ public class ChangeRequestBuildStrategyImplTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
+                            null,
+                            null,
                             null
                     ),
                     is(false)
@@ -85,6 +89,8 @@ public class ChangeRequestBuildStrategyImplTest {
                             head,
                             new MockChangeRequestSCMRevision(head,
                                     new MockSCMRevision(new MockSCMHead("master"), "dummy"), "dummy"),
+                            null,
+                            null,
                             null
                     ),
                     is(true)
@@ -106,6 +112,8 @@ public class ChangeRequestBuildStrategyImplTest {
                             head,
                             new MockChangeRequestSCMRevision(head,
                                     new MockSCMRevision(new MockSCMHead("master"), "dummy"), "dummy"),
+                            null,
+                            null,
                             null
                     ),
                     is(true)
@@ -135,6 +143,8 @@ public class ChangeRequestBuildStrategyImplTest {
                             head,
                             new MockChangeRequestSCMRevision(head,
                                     new MockSCMRevision(new MockSCMHead("master"), "dummy"), "dummy"),
+                            null,
+                            null,
                             null
                     ),
                     is(false)
@@ -156,6 +166,8 @@ public class ChangeRequestBuildStrategyImplTest {
                             head,
                             new MockChangeRequestSCMRevision(head,
                                     new MockSCMRevision(new MockSCMHead("master"), "dummy"), "dummy"),
+                            null,
+                            null,
                             null
                     ),
                     is(false)
@@ -174,6 +186,8 @@ public class ChangeRequestBuildStrategyImplTest {
                             head,
                             new MockChangeRequestSCMRevision(head,
                                     new MockSCMRevision(new MockSCMHead("master"), "dummy"), "dummy"),
+                            null,
+                            null,
                             null
                     ),
                     is(true)
@@ -212,7 +226,9 @@ public class ChangeRequestBuildStrategyImplTest {
                             new MockChangeRequestSCMRevision(head,
                                     new MockSCMRevision(new MockSCMHead("master"), "dummy"), "new-dummy"),
                             new MockChangeRequestSCMRevision(head,
-                                    new MockSCMRevision(new MockSCMHead("master"), "old-dummy"), "dummy")
+                                    new MockSCMRevision(new MockSCMHead("master"), "old-dummy"), "dummy"),
+                            null,
+                            null
                     ),
                     is(true)
             );
@@ -231,7 +247,9 @@ public class ChangeRequestBuildStrategyImplTest {
                             new MockChangeRequestSCMRevision(head,
                                     new MockSCMRevision(new MockSCMHead("master"), "dummy"), "dummy"),
                             new MockChangeRequestSCMRevision(head,
-                                    new MockSCMRevision(new MockSCMHead("master"), "old-dummy"), "dummy")
+                                    new MockSCMRevision(new MockSCMHead("master"), "old-dummy"), "dummy"),
+                            null,
+                            null
                     ),
                     is(false)
             );

--- a/src/test/java/jenkins/branch/buildstrategies/basic/NamedBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/NamedBranchBuildStrategyImplTest.java
@@ -52,6 +52,7 @@ public class NamedBranchBuildStrategyImplTest {
                             head,
                             new MockSCMRevision(head, "dummy"),
                             null,
+                            null,
                             null
                     ),
                     is(true)
@@ -70,6 +71,7 @@ public class NamedBranchBuildStrategyImplTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
+                            null,
                             null,
                             null
                     ),
@@ -92,6 +94,7 @@ public class NamedBranchBuildStrategyImplTest {
                             new MockChangeRequestSCMRevision(head,
                                     new MockSCMRevision(new MockSCMHead("master"), "dummy"), "dummy"),
                             null,
+                            null,
                             null
                     ),
                     is(false)
@@ -110,6 +113,7 @@ public class NamedBranchBuildStrategyImplTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
+                            null,
                             null,
                             null
                     ),
@@ -134,6 +138,7 @@ public class NamedBranchBuildStrategyImplTest {
                             head,
                             new MockSCMRevision(head, "dummy"),
                             null,
+                            null,
                             null
                     ),
                     is(false)
@@ -157,6 +162,7 @@ public class NamedBranchBuildStrategyImplTest {
                             head,
                             new MockSCMRevision(head, "dummy"),
                             null,
+                            null,
                             null
                     ),
                     is(true)
@@ -179,6 +185,7 @@ public class NamedBranchBuildStrategyImplTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
+                            null,
                             null,
                             null
                     ),

--- a/src/test/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImplTest.java
@@ -55,7 +55,7 @@ public class NoneBranchBuildStrategyImplTest {
                     new MockSCMRevision(head, "dummy"),
                     null,
                     null,
-                        null
+                    null
                 ),
                 is(false)
             );
@@ -81,7 +81,7 @@ public class NoneBranchBuildStrategyImplTest {
                     new MockSCMRevision(head, "dummy"),
                     null,
                     null,
-                        null
+                    null
                 ),
                 is(false)
             );
@@ -106,7 +106,7 @@ public class NoneBranchBuildStrategyImplTest {
                     new MockSCMRevision(head, "dummy"),
                     null,
                     null,
-                        null
+                    null
                 ),
                 is(true)
             );
@@ -132,7 +132,7 @@ public class NoneBranchBuildStrategyImplTest {
                     new MockSCMRevision(head, "dummy"),
                     null,
                     null,
-                        null
+                    null
                 ),
                 is(false)
             );

--- a/src/test/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImplTest.java
@@ -74,6 +74,12 @@ public class NoneBranchBuildStrategyImplTest {
                         public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision, SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
                             return true;
                         }
+                    },
+                    new BranchBuildStrategy() {
+                        @Override
+                        public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision, SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
+                            return true;
+                        }
                     }
                 )).isAutomaticBuild(
                     new MockSCMSource(c, "dummy"),
@@ -94,6 +100,12 @@ public class NoneBranchBuildStrategyImplTest {
             MockSCMHead head = new MockSCMHead("master");
             assertThat(
                 new NoneBranchBuildStrategyImpl(Arrays.asList(
+                    new BranchBuildStrategy() {
+                        @Override
+                        public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision, SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
+                            return false;
+                        }
+                    },
                     new BranchBuildStrategy() {
                         @Override
                         public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision, SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
@@ -124,6 +136,13 @@ public class NoneBranchBuildStrategyImplTest {
                         @Override
                         public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision, SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
                             return true;
+                        }
+                    },
+                    new BranchBuildStrategy() {
+                        @Override
+                        public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision, SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
+                            fail("strategy evaluation must short circuit");
+                            return false;
                         }
                     }
                 )).isAutomaticBuild(

--- a/src/test/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImplTest.java
@@ -71,13 +71,7 @@ public class NoneBranchBuildStrategyImplTest {
                 new NoneBranchBuildStrategyImpl(Arrays.asList(
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
-                            return true;
-                        }
-                    },
-                    new BranchBuildStrategy() {
-                        @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision, SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
                             return true;
                         }
                     }
@@ -102,13 +96,7 @@ public class NoneBranchBuildStrategyImplTest {
                 new NoneBranchBuildStrategyImpl(Arrays.asList(
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
-                            return false;
-                        }
-                    },
-                    new BranchBuildStrategy() {
-                        @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision, SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
                             return false;
                         }
                     }
@@ -134,15 +122,8 @@ public class NoneBranchBuildStrategyImplTest {
                 new NoneBranchBuildStrategyImpl(Arrays.asList(
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision, SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener taskListener) {
                             return true;
-                        }
-                    },
-                    new BranchBuildStrategy() {
-                        @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
-                            fail("strategy evaluation must short circuit");
-                            return false;
                         }
                     }
                 )).isAutomaticBuild(

--- a/src/test/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImplTest.java
@@ -54,7 +54,8 @@ public class NoneBranchBuildStrategyImplTest {
                     head,
                     new MockSCMRevision(head, "dummy"),
                     null,
-                    null
+                    null,
+                        null
                 ),
                 is(false)
             );
@@ -70,13 +71,13 @@ public class NoneBranchBuildStrategyImplTest {
                 new NoneBranchBuildStrategyImpl(Arrays.asList(
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
                             return true;
                         }
                     },
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
                             return true;
                         }
                     }
@@ -85,7 +86,8 @@ public class NoneBranchBuildStrategyImplTest {
                     head,
                     new MockSCMRevision(head, "dummy"),
                     null,
-                    null
+                    null,
+                        null
                 ),
                 is(false)
             );
@@ -100,13 +102,13 @@ public class NoneBranchBuildStrategyImplTest {
                 new NoneBranchBuildStrategyImpl(Arrays.asList(
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
                             return false;
                         }
                     },
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
                             return false;
                         }
                     }
@@ -115,7 +117,8 @@ public class NoneBranchBuildStrategyImplTest {
                     head,
                     new MockSCMRevision(head, "dummy"),
                     null,
-                    null
+                    null,
+                        null
                 ),
                 is(true)
             );
@@ -131,13 +134,13 @@ public class NoneBranchBuildStrategyImplTest {
                 new NoneBranchBuildStrategyImpl(Arrays.asList(
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
                             return true;
                         }
                     },
                     new BranchBuildStrategy() {
                         @Override
-                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener) {
+                        public boolean isAutomaticBuild(@NonNull SCMSource scmSource, @NonNull SCMHead scmHead, @NonNull SCMRevision scmRevision, SCMRevision scmRevision1, TaskListener taskListener, SCMRevision lastSeenRevision) {
                             fail("strategy evaluation must short circuit");
                             return false;
                         }
@@ -147,7 +150,8 @@ public class NoneBranchBuildStrategyImplTest {
                     head,
                     new MockSCMRevision(head, "dummy"),
                     null,
-                    null
+                    null,
+                        null
                 ),
                 is(false)
             );

--- a/src/test/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexingTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexingTest.java
@@ -58,7 +58,7 @@ public class SkipInitialBuildOnFirstBranchIndexingTest {
     public static JenkinsRule j = new JenkinsRule();
 
     @Test
-    public void given__no__scm__prev_revision__isAutomaticBuild__then__returns_false() throws Exception {
+    public void given__no__scm__lastSeenRevision__isAutomaticBuild__then__returns_false() throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
             MockSCMHead head = new MockSCMHead("master");
             assertThat(
@@ -76,7 +76,7 @@ public class SkipInitialBuildOnFirstBranchIndexingTest {
     }
 
     @Test
-    public void given__scm__prev_revision__isAutomaticBuild__then__returns_true() throws Exception {
+    public void given__scm__lastSeenRevision__isAutomaticBuild__then__returns_true() throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
             MockSCMHead head = new MockSCMHead("master");
             assertThat(
@@ -84,9 +84,9 @@ public class SkipInitialBuildOnFirstBranchIndexingTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
-                            new MockSCMRevision(head, "dummy"),
                             null,
-                            null
+                            null,
+                            new MockSCMRevision(head, "dummy")
                     ),
                     is(true)
             );
@@ -97,7 +97,7 @@ public class SkipInitialBuildOnFirstBranchIndexingTest {
     public void if__first__branch__indexing__isAutomaticBuild__then__returns__true() throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
             c.createRepository("foo");
-            BasicMultiBranchProject prj = j.jenkins.createProject(BasicMultiBranchProject.class, "my-project");
+            BasicMultiBranchProject prj = j.jenkins.createProject(BasicMultiBranchProject.class, "project");
             prj.setCriteria(null);
             BranchSource source = new BranchSource(new MockSCMSource(c, "foo", new MockSCMDiscoverBranches()));
             source.setBuildStrategies(Collections.<BranchBuildStrategy>singletonList(new SkipInitialBuildOnFirstBranchIndexing()));

--- a/src/test/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexingTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexingTest.java
@@ -67,6 +67,7 @@ public class SkipInitialBuildOnFirstBranchIndexingTest {
                             head,
                             new MockSCMRevision(head, "dummy"),
                             null,
+                            null,
                             null
                     ),
                     is(false)
@@ -84,6 +85,7 @@ public class SkipInitialBuildOnFirstBranchIndexingTest {
                             head,
                             new MockSCMRevision(head, "dummy"),
                             new MockSCMRevision(head, "dummy"),
+                            null,
                             null
                     ),
                     is(true)

--- a/src/test/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexingTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexingTest.java
@@ -85,8 +85,8 @@ public class SkipInitialBuildOnFirstBranchIndexingTest {
                             head,
                             new MockSCMRevision(head, "dummy"),
                             null,
-                            null,
-                            new MockSCMRevision(head, "dummy")
+                            new MockSCMRevision(head, "dummy"),
+                            null
                     ),
                     is(true)
             );

--- a/src/test/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImplTest.java
@@ -49,6 +49,7 @@ public class TagBuildStrategyImplTest {
                             head,
                             new MockSCMRevision(head, "dummy"),
                             null,
+                            null,
                             null
                     ),
                     is(false)
@@ -65,6 +66,7 @@ public class TagBuildStrategyImplTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
+                            null,
                             null,
                             null
                     ),
@@ -83,6 +85,7 @@ public class TagBuildStrategyImplTest {
                             head,
                             new MockSCMRevision(head, "dummy"),
                             null,
+                            null,
                             null
                     ),
                     is(true)
@@ -99,6 +102,7 @@ public class TagBuildStrategyImplTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
+                            null,
                             null,
                             null
                     ),
@@ -117,6 +121,7 @@ public class TagBuildStrategyImplTest {
                             head,
                             new MockSCMRevision(head, "dummy"),
                             null,
+                            null,
                             null
                     ),
                     is(false)
@@ -133,6 +138,7 @@ public class TagBuildStrategyImplTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
+                            null,
                             null,
                             null
                     ),
@@ -152,6 +158,7 @@ public class TagBuildStrategyImplTest {
                                 head,
                                 new MockSCMRevision(head, "dummy"),
                                 null,
+                                null,
                                 null
                         ),
                         is(false)
@@ -170,6 +177,7 @@ public class TagBuildStrategyImplTest {
                             head,
                             new MockSCMRevision(head, "dummy"),
                             null,
+                            null,
                             null
                     ),
                     is(false)
@@ -187,6 +195,7 @@ public class TagBuildStrategyImplTest {
                             head,
                             new MockSCMRevision(head, "dummy"),
                             null,
+                            null,
                             null
                     ),
                     is(true)
@@ -203,6 +212,7 @@ public class TagBuildStrategyImplTest {
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
+                            null,
                             null,
                             null
                     ),
@@ -222,6 +232,7 @@ public class TagBuildStrategyImplTest {
                             head,
                             new MockChangeRequestSCMRevision(head,
                                     new MockSCMRevision(new MockSCMHead("master"), "dummy"), "dummy"),
+                            null,
                             null,
                             null
                     ),


### PR DESCRIPTION
This PR depends on the PR below of the branch-api-plugin

The PR intends to use the new functionality introduced by branch-api to provide  `lastSeenRevision` + `lastBuilt`

* https://github.com/jenkinsci/branch-api-plugin/pull/149

CC @rsandell @stephenc @drdamour 