### PR TITLE
[JENKINS-56984] Fix layering

### DIFF
--- a/src/main/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl.java
@@ -74,7 +74,7 @@ public class AllBranchBuildStrategyImpl extends BranchBuildStrategy {
         }
 
         for (BranchBuildStrategy strategy: strategies) {
-            if(!strategy.isAutomaticBuild(
+            if(!strategy.automaticBuild(
                 source,
                 head,
                 currRevision,

--- a/src/main/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl.java
@@ -73,7 +73,7 @@ public class AnyBranchBuildStrategyImpl extends BranchBuildStrategy {
         }
 
         for (BranchBuildStrategy strategy: strategies) {
-            if(strategy.isAutomaticBuild(
+            if(strategy.automaticBuild(
                 source,
                 head,
                 currRevision,

--- a/src/main/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl.java
@@ -73,7 +73,7 @@ public class NoneBranchBuildStrategyImpl extends BranchBuildStrategy {
         }
 
         for (BranchBuildStrategy strategy: strategies) {
-            if(strategy.isAutomaticBuild(
+            if(strategy.automaticBuild(
                 source,
                 head,
                 currRevision,


### PR DESCRIPTION
- The API is what we expose to external code.
- The SPI is the service provider interface, i.e. what implementations must provide to the API in order for the API to work
- Thus the only code that is allowed to invoke the SPI is the API code
- These implementations are thus API consumers as well as SPI implementers
- But in this case we have the SPI calling the SPI which prevents the SPI contract from evolving
- Thus we switch the implementations to call the API of the delegate implementations
- This does mean that as we evolve the SPI, these 'aggregator' strategies may obscure features, but it does mean they will not break completely

See [JENKINS-56984](https://issues.jenkins-ci.org/browse/JENKINS-56984)