### PR TITLE
Add option to ignore all change requests

### DIFF
--- a/src/main/java/jenkins/branch/buildstrategies/basic/ChangeRequestBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/ChangeRequestBuildStrategyImpl.java
@@ -59,6 +59,7 @@ public class ChangeRequestBuildStrategyImpl extends BranchBuildStrategy {
     private static final Logger LOGGER = Logger.getLogger(ChangeRequestBuildStrategyImpl.class.getName());
     private final boolean ignoreTargetOnlyChanges;
     private final boolean ignoreUntrustedChanges;
+    private final boolean ignoreAllChanges;
 
     /**
      * Our constructor.
@@ -80,11 +81,28 @@ public class ChangeRequestBuildStrategyImpl extends BranchBuildStrategy {
      *         the target branch revision.
      * @param ignoreUntrustedChanges {@code true} to check the trusted revision and ignore if different, which
      *         would have the effect of ignoring change requests that originate from an untrusted source.
+     * @deprecated use {@link #ChangeRequestBuildStrategyImpl(boolean, boolean, boolean)}
+     * @since 1.3.3
+     */
+    @Deprecated
+    public ChangeRequestBuildStrategyImpl(boolean ignoreTargetOnlyChanges, boolean ignoreUntrustedChanges) {
+        this(ignoreTargetOnlyChanges, ignoreUntrustedChanges, false);
+    }
+
+    /**
+     * Our constructor.
+     *
+     * @param ignoreTargetOnlyChanges {@code true} to ignore merge revision changes where the only difference is
+     *         the target branch revision.
+     * @param ignoreUntrustedChanges {@code true} to check the trusted revision and ignore if different, which
+     *         would have the effect of ignoring change requests that originate from an untrusted source.
+     * @param ignoreAllChanges {@code true} to ignore all change requests.
      */
     @DataBoundConstructor
-    public ChangeRequestBuildStrategyImpl(boolean ignoreTargetOnlyChanges, boolean ignoreUntrustedChanges) {
+    public ChangeRequestBuildStrategyImpl(boolean ignoreTargetOnlyChanges, boolean ignoreUntrustedChanges, boolean ignoreAllChanges) {
         this.ignoreTargetOnlyChanges = ignoreTargetOnlyChanges;
         this.ignoreUntrustedChanges = ignoreUntrustedChanges;
+        this.ignoreAllChanges = ignoreAllChanges;
     }
 
     public boolean isIgnoreTargetOnlyChanges() {
@@ -94,6 +112,8 @@ public class ChangeRequestBuildStrategyImpl extends BranchBuildStrategy {
     public boolean isIgnoreUntrustedChanges() {
         return ignoreUntrustedChanges;
     }
+
+    public boolean isIgnoreAllChanges() { return ignoreAllChanges; }
 
     /**
      * {@inheritDoc}
@@ -124,6 +144,9 @@ public class ChangeRequestBuildStrategyImpl extends BranchBuildStrategy {
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     @CheckForNull SCMRevision lastBuiltRevision, @CheckForNull SCMRevision lastSeenRevision, @NonNull TaskListener listener) {
         if (!(head instanceof ChangeRequestSCMHead)) {
+            return false;
+        }
+        if (ignoreAllChanges) {
             return false;
         }
         if (ignoreTargetOnlyChanges
@@ -182,6 +205,7 @@ public class ChangeRequestBuildStrategyImpl extends BranchBuildStrategy {
         return "ChangeRequestBuildStrategyImpl{" +
                 "ignoreTargetOnlyChanges=" + ignoreTargetOnlyChanges +
                 "ignoreUntrustedChanges=" + ignoreUntrustedChanges +
+                "ignoreAllChanges=" + ignoreAllChanges +
                 '}';
     }
 

--- a/src/main/resources/jenkins/branch/buildstrategies/basic/ChangeRequestBuildStrategyImpl/config.jelly
+++ b/src/main/resources/jenkins/branch/buildstrategies/basic/ChangeRequestBuildStrategyImpl/config.jelly
@@ -29,4 +29,7 @@
   <f:entry field="ignoreUntrustedChanges">
     <f:checkbox title="${%Ignore change requests flagged as originating from an untrusted source}"/>
   </f:entry>
+  <f:entry field="ignoreAllChanges">
+    <f:checkbox title="${%Ignore all change requests}"/>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/jenkins/branch/buildstrategies/basic/ChangeRequestBuildStrategyImpl/help-ignoreAllChanges.html
+++ b/src/main/resources/jenkins/branch/buildstrategies/basic/ChangeRequestBuildStrategyImpl/help-ignoreAllChanges.html
@@ -22,5 +22,6 @@
  ~ THE SOFTWARE.
  -->
 <div>
-  Configure build strategy for change requests / pull requests
+    Selecting this option will ignore all change requests.
+    <br/>
 </div>

--- a/src/test/java/jenkins/branch/buildstrategies/basic/ChangeRequestBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/ChangeRequestBuildStrategyImplTest.java
@@ -47,7 +47,7 @@ public class ChangeRequestBuildStrategyImplTest {
         try (MockSCMController c = MockSCMController.create()) {
             MockSCMHead head = new MockSCMHead("master");
             assertThat(
-                    new ChangeRequestBuildStrategyImpl(false, false).isAutomaticBuild(
+                    new ChangeRequestBuildStrategyImpl(false, false, false).isAutomaticBuild(
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
@@ -65,7 +65,7 @@ public class ChangeRequestBuildStrategyImplTest {
         try (MockSCMController c = MockSCMController.create()) {
             MockSCMHead head = new MockTagSCMHead("master", System.currentTimeMillis());
             assertThat(
-                    new ChangeRequestBuildStrategyImpl(false, false).isAutomaticBuild(
+                    new ChangeRequestBuildStrategyImpl(false, false, false).isAutomaticBuild(
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockSCMRevision(head, "dummy"),
@@ -84,7 +84,7 @@ public class ChangeRequestBuildStrategyImplTest {
             MockChangeRequestSCMHead head = new MockChangeRequestSCMHead(SCMHeadOrigin.DEFAULT, 1, "master",
                     ChangeRequestCheckoutStrategy.MERGE, true);
             assertThat(
-                    new ChangeRequestBuildStrategyImpl(false, false).isAutomaticBuild(
+                    new ChangeRequestBuildStrategyImpl(false, false, false).isAutomaticBuild(
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockChangeRequestSCMRevision(head,
@@ -107,7 +107,7 @@ public class ChangeRequestBuildStrategyImplTest {
             MockChangeRequestSCMHead head = new MockChangeRequestSCMHead(SCMHeadOrigin.DEFAULT, crNum, "master",
                     ChangeRequestCheckoutStrategy.MERGE, true);
             assertThat(
-                    new ChangeRequestBuildStrategyImpl(false, true).isAutomaticBuild(
+                    new ChangeRequestBuildStrategyImpl(false, true, false).isAutomaticBuild(
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockChangeRequestSCMRevision(head,
@@ -138,7 +138,7 @@ public class ChangeRequestBuildStrategyImplTest {
                 }
             });
             assertThat(
-                    new ChangeRequestBuildStrategyImpl(false, true).isAutomaticBuild(
+                    new ChangeRequestBuildStrategyImpl(false, true, false).isAutomaticBuild(
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockChangeRequestSCMRevision(head,
@@ -161,7 +161,7 @@ public class ChangeRequestBuildStrategyImplTest {
             MockChangeRequestSCMHead head = new MockChangeRequestSCMHead(SCMHeadOrigin.DEFAULT, crNum, "master",
                     ChangeRequestCheckoutStrategy.MERGE, true);
             assertThat(
-                    new ChangeRequestBuildStrategyImpl(false, true).isAutomaticBuild(
+                    new ChangeRequestBuildStrategyImpl(false, true, false).isAutomaticBuild(
                             new MockSCMSource(c, "dummy"),
                             head,
                             new MockChangeRequestSCMRevision(head,
@@ -248,6 +248,69 @@ public class ChangeRequestBuildStrategyImplTest {
                                     new MockSCMRevision(new MockSCMHead("master"), "dummy"), "dummy"),
                             new MockChangeRequestSCMRevision(head,
                                     new MockSCMRevision(new MockSCMHead("master"), "old-dummy"), "dummy"),
+                            null,
+                            null
+                    ),
+                    is(false)
+            );
+        }
+    }
+
+    @Test
+    public void given__cr_head_ignoring_all__when__isAutomaticBuild__then__returns_false() throws Exception {
+        try (MockSCMController c = MockSCMController.create()) {
+            MockChangeRequestSCMHead head = new MockChangeRequestSCMHead(SCMHeadOrigin.DEFAULT, 1, "master",
+                    ChangeRequestCheckoutStrategy.MERGE, true);
+            assertThat(
+                    new ChangeRequestBuildStrategyImpl(false, false, true).isAutomaticBuild(
+                            new MockSCMSource(c, "dummy"),
+                            head,
+                            new MockChangeRequestSCMRevision(head,
+                                    new MockSCMRevision(new MockSCMHead("master"), "dummy"), "dummy"),
+                            null,
+                            null,
+                            null
+                    ),
+                    is(false)
+            );
+        }
+    }
+
+    @Test
+    public void given__cr_head_ignoring_all_and_ignoring_target_changes__when__first_build__then__isAutomaticBuild_returns_false() throws Exception {
+        try (MockSCMController c = MockSCMController.create()) {
+            MockChangeRequestSCMHead head = new MockChangeRequestSCMHead(SCMHeadOrigin.DEFAULT, 1, "master",
+                    ChangeRequestCheckoutStrategy.MERGE, true);
+            assertThat(
+                    new ChangeRequestBuildStrategyImpl(true, false, true).isAutomaticBuild(
+                            new MockSCMSource(c, "dummy"),
+                            head,
+                            new MockChangeRequestSCMRevision(head,
+                                    new MockSCMRevision(new MockSCMHead("master"), "dummy"), "dummy"),
+                            null,
+                            null,
+                            null
+                    ),
+                    is(false)
+            );
+        }
+    }
+
+    @Test
+    public void given__cr_head_ignoring_all_and_untrusted_changes_when__trusted_revision__then__isAutomaticBuild_returns_false() throws Exception {
+        try (MockSCMController c = MockSCMController.create()) {
+            c.createRepository("dummy", MockRepositoryFlags.TRUST_AWARE);
+            Integer crNum = c.openChangeRequest("dummy", "master");
+
+            MockChangeRequestSCMHead head = new MockChangeRequestSCMHead(SCMHeadOrigin.DEFAULT, crNum, "master",
+                    ChangeRequestCheckoutStrategy.MERGE, true);
+            assertThat(
+                    new ChangeRequestBuildStrategyImpl(false, true, true).isAutomaticBuild(
+                            new MockSCMSource(c, "dummy"),
+                            head,
+                            new MockChangeRequestSCMRevision(head,
+                                    new MockSCMRevision(new MockSCMHead("master"), "dummy"), "dummy"),
+                            null,
                             null,
                             null
                     ),


### PR DESCRIPTION
This PR adds the option to ignore all change requests, imitating the older `Suppress Automatic SCM trigger` option for change requests.

Our particular use-case consists of a jenkins github-multi-branch job being powered by [prow](https://github.com/kubernetes/test-infra/tree/master/prow). Currently the job is triggered twice, once from prow, and again from the webhook trigger. Disabling the webhook in github will not work because the PR's are then not detected.