### PR TITLE
Skip build on matched jobs if manual scan is clicked

### DIFF
--- a/src/main/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexing.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexing.java
@@ -26,6 +26,8 @@ package jenkins.branch.buildstrategies.basic;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.TaskListener;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
@@ -41,6 +43,8 @@ import javax.annotation.CheckForNull;
 @Restricted(NoExternalUse.class)
 @Extension
 public class SkipInitialBuildOnFirstBranchIndexing extends BranchBuildStrategy {
+
+    private static final Logger LOGGER = Logger.getLogger(SkipInitialBuildOnFirstBranchIndexing.class.getName());
 
     @DataBoundConstructor
     public SkipInitialBuildOnFirstBranchIndexing() {
@@ -62,7 +66,12 @@ public class SkipInitialBuildOnFirstBranchIndexing extends BranchBuildStrategy {
     @Override
     public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head, @NonNull SCMRevision currRevision,
                                     @CheckForNull SCMRevision lastBuiltRevision, @CheckForNull SCMRevision lastSeenRevision, @NonNull TaskListener taskListener) {
-        if (lastSeenRevision != null) {
+        LOGGER.log(Level.INFO, "lastSeenRevision: {0}, currRevision: {1}",
+                new Object[]{
+                    lastSeenRevision, currRevision
+                }
+        );
+        if (lastSeenRevision != null && !lastSeenRevision.equals(currRevision)) {
             return true;
         }
         return false;

--- a/src/test/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexingTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexingTest.java
@@ -76,7 +76,7 @@ public class SkipInitialBuildOnFirstBranchIndexingTest {
     }
 
     @Test
-    public void given__scm__lastSeenRevision__isAutomaticBuild__then__returns_true() throws Exception {
+    public void given__scm__lastSeenRevision__but__not__equal__to__currRevision__isAutomaticBuild__then__returns_true() throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
             MockSCMHead head = new MockSCMHead("master");
             assertThat(
@@ -85,10 +85,29 @@ public class SkipInitialBuildOnFirstBranchIndexingTest {
                             head,
                             new MockSCMRevision(head, "dummy"),
                             null,
-                            new MockSCMRevision(head, "dummy"),
+                            new MockSCMRevision(head, "bar"),
                             null
                     ),
                     is(true)
+            );
+        }
+    }
+
+    @Test
+    public void given__scm__lastSeenRevision__equal__to__currRevision__isAutomaticBuild__then__returns_false() throws Exception {
+        try (MockSCMController c = MockSCMController.create()) {
+            MockSCMHead head = new MockSCMHead("master");
+            MockSCMRevision revision = new MockSCMRevision(head, "dummy");
+            assertThat(
+                    new SkipInitialBuildOnFirstBranchIndexing().isAutomaticBuild(
+                            new MockSCMSource(c, "dummy"),
+                            head,
+                            revision,
+                            null,
+                            revision,
+                            null
+                    ),
+                    is(false)
             );
         }
     }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Jira Issue: [JENKINS-67037](https://issues.jenkins.io/browse/JENKINS-67037)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

During all the test, no job is triggered.

As we can see, if `Scan Multibranch Pipeline Now` is clicked, as there is no change pushed to repository, the `lastSeenRevision` equals to `currRevision` in plugin log, the condition of `isAutomaticBuild` is changed to `lastSeenRevision != null && !lastSeenRevision.equals(currRevision)` from `lastSeenRevision != null`.

Test log:
`Scan Multibranch Pipeline Log` when multibranch job is firstly created
```log
Started
[Wed Nov 03 06:47:39 UTC 2021] Starting branch indexing...
Connecting to https://bitbucket.example.com using fake-user/******
Repository type: Git
Looking up pdt/test-multi-branch-pipeline for branches
Checking branch f/3 from fake-project/test-multi-branch-pipeline
      ‘Jenkinsfile’ found
    Met criteria
No automatic build triggered for f/3
Checking branch develop from fake-project/test-multi-branch-pipeline
      ‘Jenkinsfile’ found
    Met criteria
No automatic build triggered for develop
Checking branch f/1 from fake-project/test-multi-branch-pipeline
      ‘Jenkinsfile’ found
    Met criteria
No automatic build triggered for f/1
Checking branch master from fake-project/test-multi-branch-pipeline
      ‘Jenkinsfile’ found
    Met criteria
No automatic build triggered for master

  4 branches were processed
Looking up fake-project/test-multi-branch-pipeline for pull requests

  0 pull requests were processed
[Wed Nov 03 06:47:51 UTC 2021] Finished branch indexing. Indexing took 11 sec
Finished: SUCCESS
```

plugin log when multibranch job is firstly created,

```log
Nov 03, 2021 6:47:45 AM INFO jenkins.branch.buildstrategies.basic.SkipInitialBuildOnFirstBranchIndexing isAutomaticBuild
lastSeenRevision: null, currRevision: e7bac7413385dba1dd7029ad3db5dc948346c3b1
Nov 03, 2021 6:47:47 AM INFO jenkins.branch.buildstrategies.basic.SkipInitialBuildOnFirstBranchIndexing isAutomaticBuild
lastSeenRevision: null, currRevision: 98b83831844a0056b7730f4d3707d9b7dc00463b
Nov 03, 2021 6:47:49 AM INFO jenkins.branch.buildstrategies.basic.SkipInitialBuildOnFirstBranchIndexing isAutomaticBuild
lastSeenRevision: null, currRevision: b6a11e686a6acd82cf90ea7dbf9b6e14bb0d43a6
Nov 03, 2021 6:47:51 AM INFO jenkins.branch.buildstrategies.basic.SkipInitialBuildOnFirstBranchIndexing isAutomaticBuild
lastSeenRevision: null, currRevision: 9e3fe7ddb28c0d60950dc81989e170eb3ba8feb9
```

Scan Multibranch Pipeline Log after `Scan Multibranch Pipeline Now` is clicked

```log
Started by user admin
[Wed Nov 03 06:51:09 UTC 2021] Starting branch indexing...
Connecting to https://bitbucket.example.com using fake-user/******
Repository type: Git
Looking up fake-project/test-multi-branch-pipeline for branches
Checking branch f/3 from fake-project/test-multi-branch-pipeline
      ‘Jenkinsfile’ found
    Met criteria
Changes detected: f/3 (null → e7bac7413385dba1dd7029ad3db5dc948346c3b1)
No automatic build triggered for f/3
Checking branch develop from fake-project/test-multi-branch-pipeline
      ‘Jenkinsfile’ found
    Met criteria
Changes detected: develop (null → 98b83831844a0056b7730f4d3707d9b7dc00463b)
No automatic build triggered for develop
Checking branch f/1 from fake-project/test-multi-branch-pipeline
      ‘Jenkinsfile’ found
    Met criteria
Changes detected: f/1 (null → b6a11e686a6acd82cf90ea7dbf9b6e14bb0d43a6)
No automatic build triggered for f/1
Checking branch master from fake-project/test-multi-branch-pipeline
      ‘Jenkinsfile’ found
    Met criteria
Changes detected: master (null → 9e3fe7ddb28c0d60950dc81989e170eb3ba8feb9)
No automatic build triggered for master

  4 branches were processed
Looking up fake-project/test-multi-branch-pipeline for pull requests

  0 pull requests were processed
[Wed Nov 03 06:51:21 UTC 2021] Finished branch indexing. Indexing took 11 sec
Finished: SUCCESS
```

plugin log  after `Scan Multibranch Pipeline Now` is clicked

```log
Nov 03, 2021 6:51:15 AM INFO jenkins.branch.buildstrategies.basic.SkipInitialBuildOnFirstBranchIndexing isAutomaticBuild
lastSeenRevision: e7bac7413385dba1dd7029ad3db5dc948346c3b1, currRevision: e7bac7413385dba1dd7029ad3db5dc948346c3b1
Nov 03, 2021 6:51:17 AM INFO jenkins.branch.buildstrategies.basic.SkipInitialBuildOnFirstBranchIndexing isAutomaticBuild
lastSeenRevision: 98b83831844a0056b7730f4d3707d9b7dc00463b, currRevision: 98b83831844a0056b7730f4d3707d9b7dc00463b
Nov 03, 2021 6:51:19 AM INFO jenkins.branch.buildstrategies.basic.SkipInitialBuildOnFirstBranchIndexing isAutomaticBuild
lastSeenRevision: b6a11e686a6acd82cf90ea7dbf9b6e14bb0d43a6, currRevision: b6a11e686a6acd82cf90ea7dbf9b6e14bb0d43a6
Nov 03, 2021 6:51:21 AM INFO jenkins.branch.buildstrategies.basic.SkipInitialBuildOnFirstBranchIndexing isAutomaticBuild
lastSeenRevision: 9e3fe7ddb28c0d60950dc81989e170eb3ba8feb9, currRevision: 9e3fe7ddb28c0d60950dc81989e170eb3ba8feb9
```