### PR TITLE
Update plugin dev

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -25,7 +25,7 @@ Template:
 == Version 1.2.0 (2019-03-21)
 
 * Add `Any`, `All` and `None` strategies link:https://github.com/jenkinsci/basic-branch-build-strategies-plugin/pull/3[PR-3]
-* Add `ignoreUntrustedChanges` to Chnage request build strategy
+* Add `ignoreUntrustedChanges` to Change request build strategy
 
 == Version 1.1.1 (2018-11-17)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,36 @@
 # Contribution guidelines
 
 This project follows [SCM API's Contribution Guidelines](https://github.com/jenkinsci/scm-api-plugin/blob/master/CONTRIBUTING.md).
+
+# Developer Information
+
+## Environment
+
+The following build environment is required to build this plugin
+
+- `java-1.8` and `maven-3.5.2`
+
+## Build
+
+To build the plugin locally:
+
+```
+mvn clean verify
+```
+
+## Release
+
+To release the plugin:
+
+```
+mvn release:prepare release:perform -B
+```
+
+## Test local instance
+
+To test in a local Jenkins instance
+
+```
+mvn hpi:run
+```
+

--- a/README.adoc
+++ b/README.adoc
@@ -1,10 +1,8 @@
 == Basic Branch Build Strategies Plugin
 
-This plugin provides some basic branch build strategies for use with http://wiki.jenkins.io/display/JENKINS/Branch+API+Plugin[Branch API] based projects.
+This plugin provides some basic branch build strategies for use with https://plugins.jenkins.io/branch-api/[Branch API] based projects.
 
 For generic information about how to use the Basic Branch Build Strategies plugin, please see link:docs/user{outfilesuffix}[the user guide]
-
-For other details on the plugin see http://wiki.jenkins.io/display/JENKINS/Basic+Branch+Build+Strategies+Plugin[the wiki page]
 
 For changes to the plugin see link:CHANGES{outfilesuffix}[the changelog]
 

--- a/README.adoc
+++ b/README.adoc
@@ -6,41 +6,4 @@ For generic information about how to use the Basic Branch Build Strategies plugi
 
 For changes to the plugin see link:CHANGES{outfilesuffix}[the changelog]
 
-=== Developer information
-
-The following information is provided for anyone wanting to develop this plugin.
-
-* link:CONTRIBUTING{outfilesuffix}[Contributor guidelines]
-
-==== Environment
-
-The following build environment is required to build this plugin
-
-* `java-1.8` and `maven-3.5.2`
-
-==== Build
-
-To build the plugin locally:
-
-[source,shell]
-----
-mvn clean verify
-----
-
-==== Release
-
-To release the plugin:
-
-[source,shell]
-----
-mvn release:prepare release:perform -B
-----
-
-==== Test local instance
-
-To test in a local Jenkins instance
-
-[source,shell]
-----
-mvn hpi:run
-----
+For information on contributing to this plugin see link:CONTRIBUTING{outfilesuffix}[Contributor guidelines]

--- a/README.adoc
+++ b/README.adoc
@@ -6,4 +6,4 @@ For generic information about how to use the Basic Branch Build Strategies plugi
 
 For changes to the plugin see link:CHANGES{outfilesuffix}[the changelog]
 
-For information on contributing to this plugin see link:CONTRIBUTING{outfilesuffix}[Contributor guidelines]
+For information on contributing to this plugin see link:CONTRIBUTING.md[Contributor guidelines]

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
   <description>
     This plugin provides some basic branch build strategies for use with Branch API based projects.
   </description>
-  <url>http://wiki.jenkins.io/display/JENKINS/Basic+Branch+Build+Strategies+Plugin</url>
+  <url>https://github.com/jenkinsci/basic-branch-build-strategies-plugin/blob/master/docs/user.adoc</url>
   <licenses>
     <license>
       <name>The MIT license</name>

--- a/src/main/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl.java
@@ -23,6 +23,7 @@
  */
 package jenkins.branch.buildstrategies.basic;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
@@ -42,8 +43,6 @@ import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-
-import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 /**
  * A {@link BranchBuildStrategy} that builds branches based on the results of all sub strategies matching.

--- a/src/main/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImpl.java
@@ -43,7 +43,7 @@ import jenkins.scm.api.SCMSource;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 /**
  * A {@link BranchBuildStrategy} that builds branches based on the results of all sub strategies matching.

--- a/src/main/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImpl.java
@@ -36,7 +36,7 @@ import jenkins.scm.api.SCMSource;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/jenkins/branch/buildstrategies/basic/BranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/BranchBuildStrategyImpl.java
@@ -37,7 +37,7 @@ import jenkins.scm.api.mixin.TagSCMHead;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 

--- a/src/main/java/jenkins/branch/buildstrategies/basic/NamedBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/NamedBranchBuildStrategyImpl.java
@@ -24,7 +24,6 @@
 package jenkins.branch.buildstrategies.basic;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.AbstractDescribableImpl;

--- a/src/main/java/jenkins/branch/buildstrategies/basic/NamedBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/NamedBranchBuildStrategyImpl.java
@@ -38,7 +38,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import hudson.util.LogTaskListener;
 import jenkins.branch.BranchBuildStrategy;
@@ -249,7 +249,7 @@ public class NamedBranchBuildStrategyImpl extends BranchBuildStrategy {
         @Symbol("exact")
         @Extension
         public static class DescriptorImpl extends NameFilterDescriptor {
-            @Nonnull
+            @NonNull
             @Override
             public String getDisplayName() {
                 return Messages.NamedBranchBuildStrategyImpl_exactDisplayName();
@@ -323,7 +323,7 @@ public class NamedBranchBuildStrategyImpl extends BranchBuildStrategy {
         @Symbol("regex")
         @Extension
         public static class DescriptorImpl extends NameFilterDescriptor {
-            @Nonnull
+            @NonNull
             @Override
             public String getDisplayName() {
                 return Messages.NamedBranchBuildStrategyImpl_regexDisplayName();
@@ -462,7 +462,7 @@ public class NamedBranchBuildStrategyImpl extends BranchBuildStrategy {
         @Symbol("wildcards")
         @Extension
         public static class DescriptorImpl extends NameFilterDescriptor {
-            @Nonnull
+            @NonNull
             @Override
             public String getDisplayName() {
                 return Messages.NamedBranchBuildStrategyImpl_wildcardDisplayName();

--- a/src/main/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl.java
@@ -36,7 +36,7 @@ import jenkins.scm.api.SCMSource;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImpl.java
@@ -23,6 +23,7 @@
  */
 package jenkins.branch.buildstrategies.basic;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
@@ -36,7 +37,6 @@ import jenkins.scm.api.SCMSource;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexing.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexing.java
@@ -23,6 +23,7 @@
  */
 package jenkins.branch.buildstrategies.basic;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.TaskListener;
@@ -36,9 +37,6 @@ import jenkins.scm.api.SCMSource;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
-
-import edu.umd.cs.findbugs.annotations.CheckForNull;
-
 
 @Restricted(NoExternalUse.class)
 @Extension

--- a/src/main/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexing.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexing.java
@@ -37,7 +37,7 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 
 @Restricted(NoExternalUse.class)

--- a/src/main/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImpl.java
@@ -38,7 +38,6 @@ import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
-import jenkins.scm.api.mixin.ChangeRequestSCMHead;
 import jenkins.scm.api.mixin.TagSCMHead;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;

--- a/src/test/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImplTest.java
@@ -39,7 +39,7 @@ import jenkins.scm.impl.mock.MockSCMSource;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 public class AllBranchBuildStrategyImplTest {

--- a/src/test/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImplTest.java
@@ -40,7 +40,6 @@ import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
 
 public class AllBranchBuildStrategyImplTest {
     @Test

--- a/src/test/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImplTest.java
@@ -40,7 +40,6 @@ import java.util.Collections;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
 
 public class AnyBranchBuildStrategyImplTest {
     @Test

--- a/src/test/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImplTest.java
@@ -39,7 +39,7 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 public class AnyBranchBuildStrategyImplTest {

--- a/src/test/java/jenkins/branch/buildstrategies/basic/BranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/BranchBuildStrategyImplTest.java
@@ -35,7 +35,7 @@ import jenkins.scm.impl.mock.MockTagSCMHead;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class BranchBuildStrategyImplTest {
     @Test

--- a/src/test/java/jenkins/branch/buildstrategies/basic/ChangeRequestBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/ChangeRequestBuildStrategyImplTest.java
@@ -39,7 +39,7 @@ import jenkins.scm.impl.mock.MockTagSCMHead;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ChangeRequestBuildStrategyImplTest {
     @Test

--- a/src/test/java/jenkins/branch/buildstrategies/basic/FormBindingTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/FormBindingTest.java
@@ -42,7 +42,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class FormBindingTest {
     /**

--- a/src/test/java/jenkins/branch/buildstrategies/basic/NamedBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/NamedBranchBuildStrategyImplTest.java
@@ -37,7 +37,7 @@ import jenkins.scm.impl.mock.MockTagSCMHead;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class NamedBranchBuildStrategyImplTest {
     @Test

--- a/src/test/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImplTest.java
@@ -39,7 +39,7 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 public class NoneBranchBuildStrategyImplTest {

--- a/src/test/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexingTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/SkipInitialBuildOnFirstBranchIndexingTest.java
@@ -46,7 +46,7 @@ import static org.hamcrest.Matchers.is;
 
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SkipInitialBuildOnFirstBranchIndexingTest {
 

--- a/src/test/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImplTest.java
@@ -36,7 +36,7 @@ import jenkins.scm.impl.mock.MockTagSCMHead;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TagBuildStrategyImplTest {
     @Test

--- a/src/test/java/jenkins/branch/buildstrategies/basic/harness/BasicBranchProjectFactory.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/harness/BasicBranchProjectFactory.java
@@ -24,19 +24,6 @@
  */
 package jenkins.branch.buildstrategies.basic.harness;
 
-import edu.umd.cs.findbugs.annotations.CheckForNull;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.Extension;
-import hudson.model.ItemGroup;
-import hudson.model.TaskListener;
-import java.io.IOException;
-import java.util.Map;
-import jenkins.branch.MultiBranchProject;
-import jenkins.branch.MultiBranchProjectFactory;
-import jenkins.branch.MultiBranchProjectFactoryDescriptor;
-import jenkins.scm.api.SCMSource;
-import jenkins.scm.api.SCMSourceCriteria;
-
 import hudson.BulkChange;
 import hudson.Extension;
 import hudson.model.FreeStyleBuild;

--- a/src/test/java/jenkins/branch/buildstrategies/basic/harness/BasicBranchProjectFactory.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/harness/BasicBranchProjectFactory.java
@@ -31,7 +31,6 @@ import hudson.model.ItemGroup;
 import hudson.model.TaskListener;
 import java.io.IOException;
 import java.util.Map;
-import javax.annotation.Nonnull;
 import jenkins.branch.MultiBranchProject;
 import jenkins.branch.MultiBranchProjectFactory;
 import jenkins.branch.MultiBranchProjectFactoryDescriptor;


### PR DESCRIPTION
## Update plugin development environment

Allow plugin development with Java 11 and using most recent practices from other Jenkins plugins.

* Show user docs on plugins.jenkins.io
* Use spotbugs annotations instead of javax annotations
* Use Hamcrest assertThat, not JUnit deprecated assertThat
* Remove unused imports

Includes changes from #8 and #9