### PR TITLE
Reduce differences to pom in the plugin archetype

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,10 +68,10 @@
   </developers>
 
   <scm>
-    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
-    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
-    <url>https://github.com/${gitHubRepo}</url>
+    <connection>scm:git:https://github.com/${gitHubRepo}</connection>
+    <developerConnection>scm:git:https://github.com/${gitHubRepo}</developerConnection>
     <tag>${scmTag}</tag>
+    <url>https://github.com/${gitHubRepo}</url>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,6 @@
     <license>
       <name>The MIT license</name>
       <url>https://opensource.org/licenses/MIT</url>
-      <distribution>repo</distribution>
     </license>
   </licenses>
 

--- a/pom.xml
+++ b/pom.xml
@@ -110,11 +110,11 @@
     <!-- plugin dependencies -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>scm-api</artifactId>
+      <artifactId>branch-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>branch-api</artifactId>
+      <artifactId>scm-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,6 @@
   <packaging>hpi</packaging>
 
   <name>Basic Branch Build Strategies Plugin</name>
-  <description>
-    This plugin provides some basic branch build strategies for use with Branch API based projects.
-  </description>
   <url>https://github.com/jenkinsci/basic-branch-build-strategies-plugin/blob/master/docs/user.adoc</url>
   <licenses>
     <license>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/basic-branch-build-strategies-plugin</gitHubRepo>
+    <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.version>2.361.4</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>


### PR DESCRIPTION
## Reduce differences to pom in the plugin archetype

Simplify the pom file by reducing the differences it has with the pom in the plugin archetype.  Consistency in the pom contents make it easier for others to read the pom file and detect the relevant changes that are specific to this plugin.

- Remove description from pom, read from index.jelly
- Remove the distribution property from the license
- Add a Jenkins version selection comment
- Sort the dependencies
- Use gitHubRepo consistently in scm section

### Testing done

Automated tests run successfully.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
