### PR TITLE
Replace public repo with releases repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,14 +120,60 @@
 
   <repositories>
     <repository>
-      <id>repo.jenkins-ci.org</id>
-      <url>https://repo.jenkins-ci.org/public/</url>
+      <id>releases.jenkins.io</id>
+      <url>https://repo.jenkins-ci.org/releases/</url>
     </repository>
+    <repository>
+      <id>repo1.maven.org</id>
+      <url>https://repo1.maven.org/maven2/</url>
+    </repository>
+    <repository>
+      <id>central</id>
+      <url>https://repo.maven.apache.org/maven2</url>
+    </repository>
+    <repository>
+      <id>repo.eclipse.org</id>
+      <url>https://repo.eclipse.org/content/repositories/jgit-releases/</url>
+    </repository>
+    <repository>
+      <!-- jbcrypt 1.0.0 -->
+      <id>jcenter-cache.jenkins.io</id>
+      <url>https://repo.jenkins-ci.org/jcenter-cache/</url>
+    </repository>
+    <!-- Intentionally not included in order to detect missing repositories -->
+    <!-- <repository> -->
+    <!--   <id>repo.jenkins-ci.org</id> -->
+    <!--   <url>https://repo.jenkins-ci.org/public/</url> -->
+    <!-- </repository> -->
   </repositories>
+
   <pluginRepositories>
     <pluginRepository>
-      <id>repo.jenkins-ci.org</id>
-      <url>https://repo.jenkins-ci.org/public/</url>
+      <id>releases.jenkins.io</id>
+      <url>https://repo.jenkins-ci.org/releases/</url>
     </pluginRepository>
+    <pluginRepository>
+      <id>repo1.maven.org</id>
+      <url>https://repo1.maven.org/maven2/</url>
+    </pluginRepository>
+    <pluginRepository>
+      <id>central</id>
+      <url>https://repo.maven.apache.org/maven2</url>
+    </pluginRepository>
+    <pluginRepository>
+      <id>repo.eclipse.org</id>
+      <url>https://repo.eclipse.org/content/repositories/jgit-releases/</url>
+    </pluginRepository>
+    <pluginRepository>
+      <!-- jbcrypt 1.0.0 -->
+      <id>jcenter-cache.jenkins.io</id>
+      <url>https://repo.jenkins-ci.org/jcenter-cache/</url>
+    </pluginRepository>
+    <!-- Intentionally not included in order to detect missing repositories -->
+    <!-- <pluginRepository> -->
+    <!--   <id>repo.jenkins-ci.org</id> -->
+    <!--   <url>https://repo.jenkins-ci.org/public/</url> -->
+    <!-- </pluginRepository> -->
   </pluginRepositories>
+
 </project>


### PR DESCRIPTION
## Replace public repo with releases repo

JFrog donates https://repo.jenkins-ci.org for the Jenkins project.  They host it and pay all charges associated with that hosting.

They've asked us to reduce the https://repo.jenkins-ci.org outbound bandwidth use.  One of the reductions is to retrieve released artifacts from their provider repositories instead of using https://repo.jenkins-ci.org/public as a cache of all other repositories.

This change removes https://repo.jenkins-ci.org/public from the list of repositories and replaces it with https://repo.jenkins-ci.org/releases/ for the Jenkins released artifacts and with other repositories for their artifacts.

### Testing done

Automated tests pass locally on Java 11 with Linux.  Rely on ci.jenkins.io to test Windows.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
