### PR TITLE
Replace deprecated getPastTimeString with getTimeSpanString

### DIFF
--- a/src/main/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImpl.java
@@ -210,8 +210,8 @@ public class TagBuildStrategyImpl extends BranchBuildStrategy {
     @Override
     public String toString() {
         return "TagBuildStrategyImpl{" + "atLeast="
-                + (atLeastMillis >= 0L ? Util.getPastTimeString(atLeastMillis) : "n/a") + ", atMost="
-                + (atMostMillis >= 0L ? Util.getPastTimeString(atMostMillis) : "n/a") + '}';
+                + (atLeastMillis >= 0L ? Util.getTimeSpanString(atLeastMillis) : "n/a") + ", atMost="
+                + (atMostMillis >= 0L ? Util.getTimeSpanString(atMostMillis) : "n/a") + '}';
     }
 
     /**

--- a/src/test/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImplTest.java
@@ -43,16 +43,12 @@ public class TagBuildStrategyImplTest {
     public void given__regular_head__when__isAutomaticBuild__then__returns_false() throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
             MockSCMHead head = new MockSCMHead("master");
+            TagBuildStrategyImpl tagBuildStrategy = new TagBuildStrategyImpl(null, null);
             assertThat(
-                    new TagBuildStrategyImpl(null, null)
-                            .isAutomaticBuild(
-                                    new MockSCMSource(c, "dummy"),
-                                    head,
-                                    new MockSCMRevision(head, "dummy"),
-                                    null,
-                                    null,
-                                    null),
+                    tagBuildStrategy.isAutomaticBuild(
+                            new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null, null, null),
                     is(false));
+            assertThat(tagBuildStrategy.toString(), is("TagBuildStrategyImpl{atLeast=n/a, atMost=n/a}"));
         }
     }
 
@@ -60,16 +56,12 @@ public class TagBuildStrategyImplTest {
     public void given__tag_head__when__isAutomaticBuild__then__returns_true() throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
             MockSCMHead head = new MockTagSCMHead("master", System.currentTimeMillis());
+            TagBuildStrategyImpl tagBuildStrategy = new TagBuildStrategyImpl(null, null);
             assertThat(
-                    new TagBuildStrategyImpl(null, null)
-                            .isAutomaticBuild(
-                                    new MockSCMSource(c, "dummy"),
-                                    head,
-                                    new MockSCMRevision(head, "dummy"),
-                                    null,
-                                    null,
-                                    null),
+                    tagBuildStrategy.isAutomaticBuild(
+                            new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null, null, null),
                     is(true));
+            assertThat(tagBuildStrategy.toString(), is("TagBuildStrategyImpl{atLeast=n/a, atMost=n/a}"));
         }
     }
 
@@ -78,16 +70,12 @@ public class TagBuildStrategyImplTest {
             throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
             MockSCMHead head = new MockTagSCMHead("master", System.currentTimeMillis());
+            TagBuildStrategyImpl tagBuildStrategy = new TagBuildStrategyImpl(null, "1");
             assertThat(
-                    new TagBuildStrategyImpl(null, "1")
-                            .isAutomaticBuild(
-                                    new MockSCMSource(c, "dummy"),
-                                    head,
-                                    new MockSCMRevision(head, "dummy"),
-                                    null,
-                                    null,
-                                    null),
+                    tagBuildStrategy.isAutomaticBuild(
+                            new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null, null, null),
                     is(true));
+            assertThat(tagBuildStrategy.toString(), is("TagBuildStrategyImpl{atLeast=n/a, atMost=1 day 0 hr}"));
         }
     }
 
@@ -96,16 +84,12 @@ public class TagBuildStrategyImplTest {
             throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
             MockSCMHead head = new MockTagSCMHead("master", System.currentTimeMillis() - TimeUnit.DAYS.toMillis(2));
+            TagBuildStrategyImpl tagBuildStrategy = new TagBuildStrategyImpl(null, "1");
             assertThat(
-                    new TagBuildStrategyImpl(null, "1")
-                            .isAutomaticBuild(
-                                    new MockSCMSource(c, "dummy"),
-                                    head,
-                                    new MockSCMRevision(head, "dummy"),
-                                    null,
-                                    null,
-                                    null),
+                    tagBuildStrategy.isAutomaticBuild(
+                            new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null),
                     is(false));
+            assertThat(tagBuildStrategy.toString(), is("TagBuildStrategyImpl{atLeast=n/a, atMost=1 day 0 hr}"));
         }
     }
 
@@ -114,16 +98,12 @@ public class TagBuildStrategyImplTest {
             throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
             MockSCMHead head = new MockTagSCMHead("master", System.currentTimeMillis());
+            TagBuildStrategyImpl tagBuildStrategy = new TagBuildStrategyImpl("1", null);
             assertThat(
-                    new TagBuildStrategyImpl("1", null)
-                            .isAutomaticBuild(
-                                    new MockSCMSource(c, "dummy"),
-                                    head,
-                                    new MockSCMRevision(head, "dummy"),
-                                    null,
-                                    null,
-                                    null),
+                    tagBuildStrategy.isAutomaticBuild(
+                            new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null, null),
                     is(false));
+            assertThat(tagBuildStrategy.toString(), is("TagBuildStrategyImpl{atLeast=1 day 0 hr, atMost=n/a}"));
         }
     }
 
@@ -132,16 +112,12 @@ public class TagBuildStrategyImplTest {
             throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
             MockSCMHead head = new MockTagSCMHead("master", System.currentTimeMillis() - TimeUnit.DAYS.toMillis(2));
+            TagBuildStrategyImpl tagBuildStrategy = new TagBuildStrategyImpl("1", null);
             assertThat(
-                    new TagBuildStrategyImpl("1", null)
-                            .isAutomaticBuild(
-                                    new MockSCMSource(c, "dummy"),
-                                    head,
-                                    new MockSCMRevision(head, "dummy"),
-                                    null,
-                                    null,
-                                    null),
+                    tagBuildStrategy.isAutomaticBuild(
+                            new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null, null, null),
                     is(true));
+            assertThat(tagBuildStrategy.toString(), is("TagBuildStrategyImpl{atLeast=1 day 0 hr, atMost=n/a}"));
         }
     }
 
@@ -152,16 +128,19 @@ public class TagBuildStrategyImplTest {
             for (int offset = 0; offset <= 4; offset++) {
                 MockSCMHead head =
                         new MockTagSCMHead("master", System.currentTimeMillis() - TimeUnit.DAYS.toMillis(offset));
+                TagBuildStrategyImpl tagBuildStrategy = new TagBuildStrategyImpl("3", "1");
                 assertThat(
-                        new TagBuildStrategyImpl("3", "1")
-                                .isAutomaticBuild(
-                                        new MockSCMSource(c, "dummy"),
-                                        head,
-                                        new MockSCMRevision(head, "dummy"),
-                                        null,
-                                        null,
-                                        null),
+                        tagBuildStrategy.isAutomaticBuild(
+                                new MockSCMSource(c, "dummy"),
+                                head,
+                                new MockSCMRevision(head, "dummy"),
+                                null,
+                                null,
+                                null),
                         is(false));
+                assertThat(
+                        tagBuildStrategy.toString(),
+                        is("TagBuildStrategyImpl{atLeast=3 days 0 hr, atMost=1 day 0 hr}"));
             }
         }
     }
@@ -171,16 +150,12 @@ public class TagBuildStrategyImplTest {
             throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
             MockSCMHead head = new MockTagSCMHead("master", System.currentTimeMillis());
+            TagBuildStrategyImpl tagBuildStrategy = new TagBuildStrategyImpl("1", "3");
             assertThat(
-                    new TagBuildStrategyImpl("1", "3")
-                            .isAutomaticBuild(
-                                    new MockSCMSource(c, "dummy"),
-                                    head,
-                                    new MockSCMRevision(head, "dummy"),
-                                    null,
-                                    null,
-                                    null),
+                    tagBuildStrategy.isAutomaticBuild(
+                            new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null),
                     is(false));
+            assertThat(tagBuildStrategy.toString(), is("TagBuildStrategyImpl{atLeast=1 day 0 hr, atMost=3 days 0 hr}"));
         }
     }
 
@@ -189,16 +164,12 @@ public class TagBuildStrategyImplTest {
             throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
             MockSCMHead head = new MockTagSCMHead("master", System.currentTimeMillis() - TimeUnit.DAYS.toMillis(2));
+            TagBuildStrategyImpl tagBuildStrategy = new TagBuildStrategyImpl("1", "3");
             assertThat(
-                    new TagBuildStrategyImpl("1", "3")
-                            .isAutomaticBuild(
-                                    new MockSCMSource(c, "dummy"),
-                                    head,
-                                    new MockSCMRevision(head, "dummy"),
-                                    null,
-                                    null,
-                                    null),
+                    tagBuildStrategy.isAutomaticBuild(
+                            new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null, null),
                     is(true));
+            assertThat(tagBuildStrategy.toString(), is("TagBuildStrategyImpl{atLeast=1 day 0 hr, atMost=3 days 0 hr}"));
         }
     }
 
@@ -207,16 +178,12 @@ public class TagBuildStrategyImplTest {
             throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
             MockSCMHead head = new MockTagSCMHead("master", System.currentTimeMillis() - TimeUnit.DAYS.toMillis(4));
+            TagBuildStrategyImpl tagBuildStrategy = new TagBuildStrategyImpl("1", "3");
             assertThat(
-                    new TagBuildStrategyImpl("1", "3")
-                            .isAutomaticBuild(
-                                    new MockSCMSource(c, "dummy"),
-                                    head,
-                                    new MockSCMRevision(head, "dummy"),
-                                    null,
-                                    null,
-                                    null),
+                    tagBuildStrategy.isAutomaticBuild(
+                            new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null, null, null),
                     is(false));
+            assertThat(tagBuildStrategy.toString(), is("TagBuildStrategyImpl{atLeast=1 day 0 hr, atMost=3 days 0 hr}"));
         }
     }
 

--- a/src/test/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImplTest.java
@@ -44,16 +44,16 @@ public class TagBuildStrategyImplTest {
     public void given__regular_head__when__isAutomaticBuild__then__returns_false() throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
             MockSCMHead head = new MockSCMHead("master");
-            TagBuildStrategyImpl tagBuildStrategy = new TagBuildStrategyImpl(null, null);
+            TagBuildStrategyImpl strategy = new TagBuildStrategyImpl(null, null);
             assertThat(
-                    tagBuildStrategy.isAutomaticBuild(
+                    strategy.isAutomaticBuild(
                             new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null),
                     is(false));
-            assertThat(tagBuildStrategy.toString(), is("TagBuildStrategyImpl{atLeast=n/a, atMost=n/a}"));
-            assertThat(tagBuildStrategy.hashCode(), is(tagBuildStrategy.hashCode())); // same object has same hash
-            assertThat(tagBuildStrategy, is(tagBuildStrategy)); // same object is equal to itself
-            assertThat(tagBuildStrategy, is(not(head))); // object of different class is not equal
-            assertThat(tagBuildStrategy.getAtLeastMillis(), is(tagBuildStrategy.getAtMostMillis()));
+            assertThat(strategy.toString(), is("TagBuildStrategyImpl{atLeast=n/a, atMost=n/a}"));
+            assertThat(strategy.hashCode(), is(strategy.hashCode())); // same object has same hash
+            assertThat(strategy, is(strategy)); // same object is equal to itself
+            assertThat(strategy, is(not(head))); // object of different class is not equal
+            assertThat(strategy.getAtLeastMillis(), is(strategy.getAtMostMillis()));
         }
     }
 
@@ -61,12 +61,12 @@ public class TagBuildStrategyImplTest {
     public void given__tag_head__when__isAutomaticBuild__then__returns_true() throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
             MockSCMHead head = new MockTagSCMHead("master", System.currentTimeMillis());
-            TagBuildStrategyImpl tagBuildStrategy = new TagBuildStrategyImpl(null, null);
+            TagBuildStrategyImpl strategy = new TagBuildStrategyImpl(null, null);
             assertThat(
-                    tagBuildStrategy.isAutomaticBuild(
+                    strategy.isAutomaticBuild(
                             new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null, null),
                     is(true));
-            assertThat(tagBuildStrategy.toString(), is("TagBuildStrategyImpl{atLeast=n/a, atMost=n/a}"));
+            assertThat(strategy.toString(), is("TagBuildStrategyImpl{atLeast=n/a, atMost=n/a}"));
         }
     }
 
@@ -75,12 +75,12 @@ public class TagBuildStrategyImplTest {
             throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
             MockSCMHead head = new MockTagSCMHead("master", System.currentTimeMillis());
-            TagBuildStrategyImpl tagBuildStrategy = new TagBuildStrategyImpl(null, "1");
+            TagBuildStrategyImpl strategy = new TagBuildStrategyImpl(null, "1");
             assertThat(
-                    tagBuildStrategy.isAutomaticBuild(
+                    strategy.isAutomaticBuild(
                             new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null, null, null),
                     is(true));
-            assertThat(tagBuildStrategy.toString(), is("TagBuildStrategyImpl{atLeast=n/a, atMost=1 day 0 hr}"));
+            assertThat(strategy.toString(), is("TagBuildStrategyImpl{atLeast=n/a, atMost=1 day 0 hr}"));
         }
     }
 
@@ -89,12 +89,12 @@ public class TagBuildStrategyImplTest {
             throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
             MockSCMHead head = new MockTagSCMHead("master", System.currentTimeMillis() - TimeUnit.DAYS.toMillis(2));
-            TagBuildStrategyImpl tagBuildStrategy = new TagBuildStrategyImpl(null, "1");
+            TagBuildStrategyImpl strategy = new TagBuildStrategyImpl(null, "1");
             assertThat(
-                    tagBuildStrategy.isAutomaticBuild(
+                    strategy.isAutomaticBuild(
                             new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null),
                     is(false));
-            assertThat(tagBuildStrategy.toString(), is("TagBuildStrategyImpl{atLeast=n/a, atMost=1 day 0 hr}"));
+            assertThat(strategy.toString(), is("TagBuildStrategyImpl{atLeast=n/a, atMost=1 day 0 hr}"));
         }
     }
 
@@ -103,12 +103,12 @@ public class TagBuildStrategyImplTest {
             throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
             MockSCMHead head = new MockTagSCMHead("master", System.currentTimeMillis());
-            TagBuildStrategyImpl tagBuildStrategy = new TagBuildStrategyImpl("1", null);
+            TagBuildStrategyImpl strategy = new TagBuildStrategyImpl("1", null);
             assertThat(
-                    tagBuildStrategy.isAutomaticBuild(
+                    strategy.isAutomaticBuild(
                             new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null, null),
                     is(false));
-            assertThat(tagBuildStrategy.toString(), is("TagBuildStrategyImpl{atLeast=1 day 0 hr, atMost=n/a}"));
+            assertThat(strategy.toString(), is("TagBuildStrategyImpl{atLeast=1 day 0 hr, atMost=n/a}"));
         }
     }
 
@@ -117,12 +117,12 @@ public class TagBuildStrategyImplTest {
             throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
             MockSCMHead head = new MockTagSCMHead("master", System.currentTimeMillis() - TimeUnit.DAYS.toMillis(2));
-            TagBuildStrategyImpl tagBuildStrategy = new TagBuildStrategyImpl("1", null);
+            TagBuildStrategyImpl strategy = new TagBuildStrategyImpl("1", null);
             assertThat(
-                    tagBuildStrategy.isAutomaticBuild(
+                    strategy.isAutomaticBuild(
                             new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null, null, null),
                     is(true));
-            assertThat(tagBuildStrategy.toString(), is("TagBuildStrategyImpl{atLeast=1 day 0 hr, atMost=n/a}"));
+            assertThat(strategy.toString(), is("TagBuildStrategyImpl{atLeast=1 day 0 hr, atMost=n/a}"));
         }
     }
 
@@ -133,9 +133,9 @@ public class TagBuildStrategyImplTest {
             for (int offset = 0; offset <= 4; offset++) {
                 MockSCMHead head =
                         new MockTagSCMHead("master", System.currentTimeMillis() - TimeUnit.DAYS.toMillis(offset));
-                TagBuildStrategyImpl tagBuildStrategy = new TagBuildStrategyImpl("3", "1");
+                TagBuildStrategyImpl strategy = new TagBuildStrategyImpl("3", "1");
                 assertThat(
-                        tagBuildStrategy.isAutomaticBuild(
+                        strategy.isAutomaticBuild(
                                 new MockSCMSource(c, "dummy"),
                                 head,
                                 new MockSCMRevision(head, "dummy"),
@@ -143,9 +143,7 @@ public class TagBuildStrategyImplTest {
                                 null,
                                 null),
                         is(false));
-                assertThat(
-                        tagBuildStrategy.toString(),
-                        is("TagBuildStrategyImpl{atLeast=3 days 0 hr, atMost=1 day 0 hr}"));
+                assertThat(strategy.toString(), is("TagBuildStrategyImpl{atLeast=3 days 0 hr, atMost=1 day 0 hr}"));
             }
         }
     }
@@ -155,12 +153,12 @@ public class TagBuildStrategyImplTest {
             throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
             MockSCMHead head = new MockTagSCMHead("master", System.currentTimeMillis());
-            TagBuildStrategyImpl tagBuildStrategy = new TagBuildStrategyImpl("1", "3");
+            TagBuildStrategyImpl strategy = new TagBuildStrategyImpl("1", "3");
             assertThat(
-                    tagBuildStrategy.isAutomaticBuild(
+                    strategy.isAutomaticBuild(
                             new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null),
                     is(false));
-            assertThat(tagBuildStrategy.toString(), is("TagBuildStrategyImpl{atLeast=1 day 0 hr, atMost=3 days 0 hr}"));
+            assertThat(strategy.toString(), is("TagBuildStrategyImpl{atLeast=1 day 0 hr, atMost=3 days 0 hr}"));
         }
     }
 
@@ -169,12 +167,12 @@ public class TagBuildStrategyImplTest {
             throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
             MockSCMHead head = new MockTagSCMHead("master", System.currentTimeMillis() - TimeUnit.DAYS.toMillis(2));
-            TagBuildStrategyImpl tagBuildStrategy = new TagBuildStrategyImpl("1", "3");
+            TagBuildStrategyImpl strategy = new TagBuildStrategyImpl("1", "3");
             assertThat(
-                    tagBuildStrategy.isAutomaticBuild(
+                    strategy.isAutomaticBuild(
                             new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null, null),
                     is(true));
-            assertThat(tagBuildStrategy.toString(), is("TagBuildStrategyImpl{atLeast=1 day 0 hr, atMost=3 days 0 hr}"));
+            assertThat(strategy.toString(), is("TagBuildStrategyImpl{atLeast=1 day 0 hr, atMost=3 days 0 hr}"));
         }
     }
 
@@ -183,12 +181,12 @@ public class TagBuildStrategyImplTest {
             throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
             MockSCMHead head = new MockTagSCMHead("master", System.currentTimeMillis() - TimeUnit.DAYS.toMillis(4));
-            TagBuildStrategyImpl tagBuildStrategy = new TagBuildStrategyImpl("1", "3");
+            TagBuildStrategyImpl strategy = new TagBuildStrategyImpl("1", "3");
             assertThat(
-                    tagBuildStrategy.isAutomaticBuild(
+                    strategy.isAutomaticBuild(
                             new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null, null, null),
                     is(false));
-            assertThat(tagBuildStrategy.toString(), is("TagBuildStrategyImpl{atLeast=1 day 0 hr, atMost=3 days 0 hr}"));
+            assertThat(strategy.toString(), is("TagBuildStrategyImpl{atLeast=1 day 0 hr, atMost=3 days 0 hr}"));
         }
     }
 

--- a/src/test/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImplTest.java
@@ -136,12 +136,7 @@ public class TagBuildStrategyImplTest {
                 TagBuildStrategyImpl strategy = new TagBuildStrategyImpl("3", "1");
                 assertThat(
                         strategy.isAutomaticBuild(
-                                new MockSCMSource(c, "dummy"),
-                                head,
-                                new MockSCMRevision(head, "dummy"),
-                                null,
-                                null,
-                                null),
+                                new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null),
                         is(false));
                 assertThat(strategy.toString(), is("TagBuildStrategyImpl{atLeast=3 days 0 hr, atMost=1 day 0 hr}"));
             }
@@ -156,7 +151,7 @@ public class TagBuildStrategyImplTest {
             TagBuildStrategyImpl strategy = new TagBuildStrategyImpl("1", "3");
             assertThat(
                     strategy.isAutomaticBuild(
-                            new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null),
+                            new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null, null),
                     is(false));
             assertThat(strategy.toString(), is("TagBuildStrategyImpl{atLeast=1 day 0 hr, atMost=3 days 0 hr}"));
         }
@@ -170,7 +165,7 @@ public class TagBuildStrategyImplTest {
             TagBuildStrategyImpl strategy = new TagBuildStrategyImpl("1", "3");
             assertThat(
                     strategy.isAutomaticBuild(
-                            new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null, null),
+                            new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null, null, null),
                     is(true));
             assertThat(strategy.toString(), is("TagBuildStrategyImpl{atLeast=1 day 0 hr, atMost=3 days 0 hr}"));
         }
@@ -184,7 +179,7 @@ public class TagBuildStrategyImplTest {
             TagBuildStrategyImpl strategy = new TagBuildStrategyImpl("1", "3");
             assertThat(
                     strategy.isAutomaticBuild(
-                            new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null, null, null),
+                            new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null),
                     is(false));
             assertThat(strategy.toString(), is("TagBuildStrategyImpl{atLeast=1 day 0 hr, atMost=3 days 0 hr}"));
         }
@@ -198,7 +193,7 @@ public class TagBuildStrategyImplTest {
             MockChangeRequestSCMRevision revision = new MockChangeRequestSCMRevision(
                     head, new MockSCMRevision(new MockSCMHead("master"), "dummy"), "dummy");
             TagBuildStrategyImpl strategy = new TagBuildStrategyImpl(null, null);
-            assertThat(strategy.isAutomaticBuild(new MockSCMSource(c, "dummy"), head, revision, null), is(false));
+            assertThat(strategy.isAutomaticBuild(new MockSCMSource(c, "dummy"), head, revision, null, null), is(false));
             assertThat(strategy.toString(), is("TagBuildStrategyImpl{atLeast=n/a, atMost=n/a}"));
         }
     }

--- a/src/test/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImplTest.java
@@ -195,17 +195,11 @@ public class TagBuildStrategyImplTest {
         try (MockSCMController c = MockSCMController.create()) {
             MockChangeRequestSCMHead head = new MockChangeRequestSCMHead(
                     SCMHeadOrigin.DEFAULT, 1, "master", ChangeRequestCheckoutStrategy.MERGE, true);
-            assertThat(
-                    new TagBuildStrategyImpl(null, null)
-                            .isAutomaticBuild(
-                                    new MockSCMSource(c, "dummy"),
-                                    head,
-                                    new MockChangeRequestSCMRevision(
-                                            head, new MockSCMRevision(new MockSCMHead("master"), "dummy"), "dummy"),
-                                    null,
-                                    null,
-                                    null),
-                    is(false));
+            MockChangeRequestSCMRevision revision = new MockChangeRequestSCMRevision(
+                    head, new MockSCMRevision(new MockSCMHead("master"), "dummy"), "dummy");
+            TagBuildStrategyImpl strategy = new TagBuildStrategyImpl(null, null);
+            assertThat(strategy.isAutomaticBuild(new MockSCMSource(c, "dummy"), head, revision, null), is(false));
+            assertThat(strategy.toString(), is("TagBuildStrategyImpl{atLeast=n/a, atMost=n/a}"));
         }
     }
 }

--- a/src/test/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImplTest.java
@@ -25,6 +25,7 @@ package jenkins.branch.buildstrategies.basic;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 import java.util.concurrent.TimeUnit;
 import jenkins.scm.api.SCMHeadOrigin;
@@ -46,9 +47,13 @@ public class TagBuildStrategyImplTest {
             TagBuildStrategyImpl tagBuildStrategy = new TagBuildStrategyImpl(null, null);
             assertThat(
                     tagBuildStrategy.isAutomaticBuild(
-                            new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null, null, null),
+                            new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null),
                     is(false));
             assertThat(tagBuildStrategy.toString(), is("TagBuildStrategyImpl{atLeast=n/a, atMost=n/a}"));
+            assertThat(tagBuildStrategy.hashCode(), is(tagBuildStrategy.hashCode())); // same object has same hash
+            assertThat(tagBuildStrategy, is(tagBuildStrategy)); // same object is equal to itself
+            assertThat(tagBuildStrategy, is(not(head))); // object of different class is not equal
+            assertThat(tagBuildStrategy.getAtLeastMillis(), is(tagBuildStrategy.getAtMostMillis()));
         }
     }
 
@@ -59,7 +64,7 @@ public class TagBuildStrategyImplTest {
             TagBuildStrategyImpl tagBuildStrategy = new TagBuildStrategyImpl(null, null);
             assertThat(
                     tagBuildStrategy.isAutomaticBuild(
-                            new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null, null, null),
+                            new MockSCMSource(c, "dummy"), head, new MockSCMRevision(head, "dummy"), null, null),
                     is(true));
             assertThat(tagBuildStrategy.toString(), is("TagBuildStrategyImpl{atLeast=n/a, atMost=n/a}"));
         }


### PR DESCRIPTION
## Replace deprecated `getPastTimeString` with `getTimeSpanString`

Replace deprecated `getPastTimeString` with `getTimeSpanString`.

Generated with [OpenRewrite](https://github.com/openrewrite/rewrite-jenkins/) using command:

```
mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
  -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-jenkins:RELEASE \
  -Drewrite.activeRecipes=org.openrewrite.jenkins.migrate.hudson.UtilGetPastTimeStringToGetTimeSpanString
```

Increases test coverage on a few `TagBuildStrategyImpl` methods.

- Assert values returned by TagBuildStrategyImpl.toString()
- Increase TagBuildStrategyImpl method coverage
- Replace deprecated getPastTimeString with getTimeSpanString

### Testing done

Automated tests pass on Linux.  Rely on ci.jenkins.io for Windows tests.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
