### PR TITLE
Test equals and hashCode more deeply

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,12 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
     </dependency>
+    <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+      <version>3.15.2</version>
+      <scope>test</scope>
+    </dependency>
     <!-- jenkins dependencies -->
     <!-- test dependencies -->
     <dependency>

--- a/src/main/java/jenkins/branch/buildstrategies/basic/ChangeRequestBuildStrategyImpl.java
+++ b/src/main/java/jenkins/branch/buildstrategies/basic/ChangeRequestBuildStrategyImpl.java
@@ -180,7 +180,8 @@ public class ChangeRequestBuildStrategyImpl extends BranchBuildStrategy {
 
         ChangeRequestBuildStrategyImpl that = (ChangeRequestBuildStrategyImpl) o;
 
-        return ignoreTargetOnlyChanges == that.ignoreTargetOnlyChanges;
+        return ignoreUntrustedChanges == that.ignoreUntrustedChanges
+                && ignoreTargetOnlyChanges == that.ignoreTargetOnlyChanges;
     }
 
     /**

--- a/src/test/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/AllBranchBuildStrategyImplTest.java
@@ -38,6 +38,7 @@ import jenkins.scm.impl.mock.MockSCMController;
 import jenkins.scm.impl.mock.MockSCMHead;
 import jenkins.scm.impl.mock.MockSCMRevision;
 import jenkins.scm.impl.mock.MockSCMSource;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
 public class AllBranchBuildStrategyImplTest {
@@ -180,5 +181,12 @@ public class AllBranchBuildStrategyImplTest {
                                     null),
                     is(false));
         }
+    }
+
+    @Test
+    public void equalsContract() {
+        EqualsVerifier.forClass(AllBranchBuildStrategyImpl.class)
+                .usingGetClass()
+                .verify();
     }
 }

--- a/src/test/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/AnyBranchBuildStrategyImplTest.java
@@ -38,6 +38,7 @@ import jenkins.scm.impl.mock.MockSCMController;
 import jenkins.scm.impl.mock.MockSCMHead;
 import jenkins.scm.impl.mock.MockSCMRevision;
 import jenkins.scm.impl.mock.MockSCMSource;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
 public class AnyBranchBuildStrategyImplTest {
@@ -180,5 +181,12 @@ public class AnyBranchBuildStrategyImplTest {
                                     null),
                     is(true));
         }
+    }
+
+    @Test
+    public void equalsContract() {
+        EqualsVerifier.forClass(AnyBranchBuildStrategyImpl.class)
+                .usingGetClass()
+                .verify();
     }
 }

--- a/src/test/java/jenkins/branch/buildstrategies/basic/BranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/BranchBuildStrategyImplTest.java
@@ -35,6 +35,7 @@ import jenkins.scm.impl.mock.MockSCMHead;
 import jenkins.scm.impl.mock.MockSCMRevision;
 import jenkins.scm.impl.mock.MockSCMSource;
 import jenkins.scm.impl.mock.MockTagSCMHead;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
 public class BranchBuildStrategyImplTest {
@@ -89,5 +90,10 @@ public class BranchBuildStrategyImplTest {
                                     null),
                     is(false));
         }
+    }
+
+    @Test
+    public void equalsContract() {
+        EqualsVerifier.forClass(BranchBuildStrategyImpl.class).usingGetClass().verify();
     }
 }

--- a/src/test/java/jenkins/branch/buildstrategies/basic/ChangeRequestBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/ChangeRequestBuildStrategyImplTest.java
@@ -39,6 +39,7 @@ import jenkins.scm.impl.mock.MockSCMHead;
 import jenkins.scm.impl.mock.MockSCMRevision;
 import jenkins.scm.impl.mock.MockSCMSource;
 import jenkins.scm.impl.mock.MockTagSCMHead;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
 public class ChangeRequestBuildStrategyImplTest {
@@ -253,5 +254,12 @@ public class ChangeRequestBuildStrategyImplTest {
                                     null),
                     is(false));
         }
+    }
+
+    @Test
+    public void equalsContract() {
+        EqualsVerifier.forClass(ChangeRequestBuildStrategyImpl.class)
+                .usingGetClass()
+                .verify();
     }
 }

--- a/src/test/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/NoneBranchBuildStrategyImplTest.java
@@ -39,6 +39,7 @@ import jenkins.scm.impl.mock.MockSCMController;
 import jenkins.scm.impl.mock.MockSCMHead;
 import jenkins.scm.impl.mock.MockSCMRevision;
 import jenkins.scm.impl.mock.MockSCMSource;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
 public class NoneBranchBuildStrategyImplTest {
@@ -182,5 +183,12 @@ public class NoneBranchBuildStrategyImplTest {
                                     null),
                     is(false));
         }
+    }
+
+    @Test
+    public void equalsContract() {
+        EqualsVerifier.forClass(NoneBranchBuildStrategyImpl.class)
+                .usingGetClass()
+                .verify();
     }
 }

--- a/src/test/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImplTest.java
+++ b/src/test/java/jenkins/branch/buildstrategies/basic/TagBuildStrategyImplTest.java
@@ -37,6 +37,7 @@ import jenkins.scm.impl.mock.MockSCMHead;
 import jenkins.scm.impl.mock.MockSCMRevision;
 import jenkins.scm.impl.mock.MockSCMSource;
 import jenkins.scm.impl.mock.MockTagSCMHead;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
 public class TagBuildStrategyImplTest {
@@ -196,5 +197,10 @@ public class TagBuildStrategyImplTest {
             assertThat(strategy.isAutomaticBuild(new MockSCMSource(c, "dummy"), head, revision, null, null), is(false));
             assertThat(strategy.toString(), is("TagBuildStrategyImpl{atLeast=n/a, atMost=n/a}"));
         }
+    }
+
+    @Test
+    public void equalsContract() {
+        EqualsVerifier.forClass(TagBuildStrategyImpl.class).usingGetClass().verify();
     }
 }


### PR DESCRIPTION
## Test equals and hashCode methods more deeply

Fixes on error in an equals method.  The ChangeRequestBuildStrategyImpl equals method was ignoring the value of ignoreTargetOnlyChanges while hashCode was honoring the value.

### Testing done

Tests pass with Java 21 on Linux.  Let ci.jenkins.io test the other items.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
